### PR TITLE
feat: hover tooltips for location; sync permanent address; include zo…

### DIFF
--- a/frontend/src/components/FreshApplicationForm.tsx
+++ b/frontend/src/components/FreshApplicationForm.tsx
@@ -1390,6 +1390,8 @@ export default function FreshApplicationForm({ onSubmit, onCancel }: FreshApplic
         addressLine: formData.applicantAddress || "",
         stateId: formData.presentStateId ?? getStateId(formData.presentState || ""),
         districtId: formData.presentDistrictId ?? getDistrictId(formData.presentDistrict || ""),
+  zoneId: formData.presentZoneId ?? undefined,
+  divisionId: formData.presentDivisionId ?? undefined,
         policeStationId: formData.presentStationId ?? getPoliceStationId(formData.presentPoliceStation || ""),
         sinceResiding: formData.residingSince
           ? new Date(formData.residingSince).toISOString()
@@ -1400,6 +1402,8 @@ export default function FreshApplicationForm({ onSubmit, onCancel }: FreshApplic
         addressLine: formData.permanentAddress || formData.applicantAddress || "",
   stateId: formData.permanentStateId ?? getStateId(formData.permanentState || formData.presentState || ""),
   districtId: formData.permanentDistrictId ?? getDistrictId(formData.permanentDistrict || formData.presentDistrict || ""),
+  zoneId: formData.permanentZoneId ?? (formData.sameAsPresent ? formData.presentZoneId : undefined),
+  divisionId: formData.permanentDivisionId ?? (formData.sameAsPresent ? formData.presentDivisionId : undefined),
   policeStationId: formData.permanentStationId ?? getPoliceStationId(formData.permanentPoliceStation || formData.presentPoliceStation || ""),
         sinceResiding: formData.residingSince
           ? new Date(formData.residingSince).toISOString()

--- a/frontend/src/components/ProceedingsForm.tsx
+++ b/frontend/src/components/ProceedingsForm.tsx
@@ -575,7 +575,7 @@ Yours faithfully,
         <div className={styles.formSection}>
           <label className={styles.formLabel}>
             Forward To (Next User/Role)
-            {actionType === 'forward' && <span className={styles.required}>*</span>}
+            {<span className={styles.required}>*</span>}
           </label>
           <div className={styles.selectContainer}>
             <Select


### PR DESCRIPTION
Address – “Same as Present”
When checked, the permanent address auto-fills and stays synchronized with the present address (both text fields and cascading dropdowns).
Permanent address dropdowns correctly display the selected values for State → District → Zone → Division → Station.

Location Selector UX
Added hover tooltips to guide users through the correct order: State → District → Zone → Division → Station.
Disabled/help cursors have been removed; tooltips now appear on hover only when prerequisites are not selected.
Removed prerequisite-based disabled styling; only parent-level disabling remains (e.g., when “Same as Present” is enabled).

Payload Correctness
Both presentAddress and permanentAddress include zoneId and divisionId.
When “Same as Present” is enabled, permanent address IDs mirror the present address IDs.

Application Detail Fixes
History now supports both FreshLicenseApplicationsFormWorkflowHistories and workflowHistory.
usersInHierarchy from the API is exposed and passed through to Proceedings.

Proceedings
The “Forward To (Next User/Role)” dropdown is populated from applicationData.usersInHierarchy.

Lists
Applicant name is derived from applicantFullName.
If unavailable, it falls back to first/middle/last name fields to prevent showing “Unknown” when parts of the name exist.