### PR TITLE
Enforce mandatory Ground Report for SHO; remove toggle, auto-generate…

### DIFF
--- a/frontend/src/app/application/[id]/page.tsx
+++ b/frontend/src/app/application/[id]/page.tsx
@@ -804,7 +804,9 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                           <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
                             {application.history && application.history.length > 0 ? (
                               <div className="space-y-4">
+
                                 {application.history.map((h, idx) => {
+                                  console.log('🔍 History item:================0101', h, idx);
                                   const color = h.action.toLowerCase().includes('forward')
                                     ? 'border-orange-500'
                                     : h.action.toLowerCase().includes('approve')


### PR DESCRIPTION
Task
  Remove the “Generate Ground Report” button.
  Make the Ground Report Letter mandatory for SHO.
  Auto-generate and always display the letter editor.
  Ensure the letter is attached to the application as a PDF (Base64 encoded) on submit.

Solution
  UI Updates:
    Removed the toggle button.
    Always show the Ground Report editor for SHO.
    Auto-generate a draft letter if empty on load.
    Added validation: submission blocked if the letter is empty.

Attachment Handling:
    Integrated jsPDF to generate an A4 PDF from the letter text.
    Converted PDF to Base64 and attached it in the API payload (attachments[]).
    Fallback: attach as Base64 text if PDF generation fails.
    Preserved existing Download/Copy/Reset actions.

Validation & Quality:
  Typecheck/build passed (no errors).
  Submission now enforces: “Ground Report Letter is required for submission.”
  Attachment payload aligned with AttachmentDto schema.
  
<img width="1868" height="847" alt="image" src="https://github.com/user-attachments/assets/ef47af4b-f237-4487-8038-f4ec999ede9a" />
