### PR TITLE
add attachments

### DIFF
--- a/frontend/src/services/sidebarApiCalls.ts
+++ b/frontend/src/services/sidebarApiCalls.ts
@@ -70,6 +70,7 @@ const transformDetailedToApplicationData = (detailedApp: any): ApplicationData =
       action: h.actionTaken || h.action || '',
       by: h.previousUserName + ' (' + h.previousRoleName + ')' || 'Unknown User',
       comments: h.remarks || undefined,
+  attachments: Array.isArray(h.attachments) ? h.attachments : (h.attachments ? [h.attachments] : []),
     };
   });
 

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -1,0 +1,21 @@
+// Filename and string helpers
+
+/**
+ * Truncate a filename by keeping the first N characters of the basename,
+ * appending ellipsis, and preserving the extension. Example:
+ *  groundreport.pdf -> groundrep...pdf (with keep=10)
+ */
+export function truncateFilename(filename: string, keep: number = 10): string {
+  if (!filename) return '';
+  const lastDot = filename.lastIndexOf('.');
+  const hasExt = lastDot > 0 && lastDot < filename.length - 1;
+  const base = hasExt ? filename.slice(0, lastDot) : filename;
+  const extNoDot = hasExt ? filename.slice(lastDot + 1) : '';
+
+  if (base.length <= keep) return filename;
+  const visible = base.slice(0, keep);
+  return `${visible}...${extNoDot}`;
+}
+
+/** Simple guard-safe accessor */
+export const safe = <T>(val: T | undefined | null, fallback: T): T => (val == null ? fallback : val);


### PR DESCRIPTION
**Application History (Data & UI)**
Displayed attachments, including the Ground Report.
Truncated Ground Report filenames to first 10 characters + “…” + extension (e.g., groundreport.pdf → groundrep...pdf).
Organized attachments into a 2-column responsive grid.

**Ensured attachments open reliably in a new tab with full content:**
Supported http(s) links, relative URLs, data URLs, and raw Base64 (converted to Blob with correct content type).

**Styling & Layout Improvements:**
Added white card background, border, padding, and shadow.
Unified Show/Hide toggle to control both remarks and attachments together.
Made attachments full-width to align with remarks.
Added Remarks header; standardized Attachments header.
Enlarged and color-coded file type icons (PDF, image, other).
Reordered layout so remarks appear above attachments.
Removed “+ Add attachments” link from header.

**Minor Cleanups**
Removed stray characters and debug remnants in the history block.

**Admin Dashboard (Red Flags)**
Fixed TypeScript errors by adding proper types for charts and data.
Dynamically imported charts and reshaped API responses for Line/Pie charts.
Improved error handling and added loading skeleton.
Cleaned up modal usage.

<img width="1838" height="838" alt="image" src="https://github.com/user-attachments/assets/76bc74b3-d6ea-4089-913f-4581a98c2578" />
