### PR TITLE
fix -header-footer-preview

### DIFF
--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -5,12 +5,11 @@ import { PageLayoutSkeleton } from '../../components/Skeleton';
 import { useRouter, usePathname } from 'next/navigation';
 import { useEffect, useState, useMemo } from 'react';
 import { Sidebar } from '@/components/Sidebar';
+import Footer from '@/components/Footer';
 
 import { LayoutProvider } from '@/config/layoutContext';
 
 import { canAccessAdmin } from '@/utils/roleUtils';
-
-import Footer from '@/components/Footer';
 
 
 

--- a/frontend/src/app/application/[id]/page.tsx
+++ b/frontend/src/app/application/[id]/page.tsx
@@ -7,6 +7,9 @@ import Header from '../../../components/Header';
 import { useAuthSync } from '../../../hooks/useAuthSync';
 import { useLayout } from '../../../config/layoutContext';
 import { ApplicationApi } from '../../../config/APIClient';
+import { useNotifications } from '../../../config/notificationContext';
+import NotificationDropdown from '../../../components/NotificationDropdown';
+import Link from 'next/link';
 import { ApplicationData } from '../../../types';
 import ProcessApplicationModal from '../../../components/ProcessApplicationModal';
 import ForwardApplicationModal from '../../../components/ForwardApplicationModal';
@@ -95,6 +98,9 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   const [isProcessing, setIsProcessing] = useState(false);
   const [isForwarding, setIsForwarding] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [showNotifications, setShowNotifications] = useState(false);
+  const { unreadCount } = useNotifications();
+  const [displayName, setDisplayName] = useState<string | undefined>(undefined);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [showTimeline, setShowTimeline] = useState(false);
   const [selectedAction, setSelectedAction] = useState<
@@ -135,6 +141,11 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   // after actions that move an application between inbox buckets.
   const { refreshCounts } = useSidebarCounts(true);
   const { executeAction, setActiveNavigationPath } = useGlobalAction();
+
+  useEffect(() => {
+    const name = user?.name || user?.username;
+    if (!authLoading && name) setDisplayName(name);
+  }, [user, authLoading]);
 
   // Open attachments from history with a robust viewer (PDF/image) in a new tab
   const openAttachment = (att: any) => {
@@ -849,7 +860,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                 </li>
               </ol>
             </nav>
-            {/* Current Status */}
+            {/* Current Status and Right Side Actions */}
             <div className='flex items-center space-x-3'>
               <div className='flex items-center space-x-2 bg-white bg-opacity-10 rounded-lg px-4 py-2'>
                 <div className='w-8 h-8 bg-white bg-opacity-20 rounded-lg flex items-center justify-center'>
@@ -881,6 +892,71 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                   </span>
                 </div>
               </div>
+              {/* Notification Bell */}
+              <div className='relative'>
+                <button
+                  onClick={() => setShowNotifications(!showNotifications)}
+                  className='p-2 text-white hover:bg-white hover:bg-opacity-10 rounded-full'
+                  aria-label='Toggle notifications'
+                  aria-expanded={showNotifications}
+                >
+                  <svg
+                    xmlns='http://www.w3.org/2000/svg'
+                    className='h-6 w-6'
+                    fill='none'
+                    viewBox='0 0 24 24'
+                    stroke='currentColor'
+                  >
+                    <path
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      strokeWidth={2}
+                      d='M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9'
+                    />
+                  </svg>
+                  {unreadCount > 0 && (
+                    <span className='absolute top-1 right-1 bg-red-500 text-white text-xs w-4 h-4 flex items-center justify-center rounded-full'>
+                      {unreadCount}
+                    </span>
+                  )}
+                </button>
+                {showNotifications && (
+                  <NotificationDropdown onClose={() => setShowNotifications(false)} />
+                )}
+              </div>
+              {/* Print Button */}
+              <button
+                onClick={() => window.print()}
+                className='p-2 text-white hover:bg-white hover:bg-opacity-10 rounded-md'
+                aria-label='Print page'
+                title='Print'
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  className='h-6 w-6'
+                  fill='none'
+                  viewBox='0 0 24 24'
+                  stroke='currentColor'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M6 9V2h12v7m-6 4v6m-6 0h12'
+                  />
+                </svg>
+              </button>
+              {/* User Profile Avatar */}
+              {!authLoading && displayName && (
+                <Link
+                  href='/settings'
+                  className='flex items-center hover:bg-white hover:bg-opacity-10 rounded-full p-1 transition-colors'
+                >
+                  <div className='bg-white text-[#001F54] rounded-full w-8 h-8 flex items-center justify-center font-bold shadow-sm'>
+                    {displayName.charAt(0).toUpperCase()}
+                  </div>
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/app/freshform/page.tsx
+++ b/frontend/src/app/freshform/page.tsx
@@ -11,8 +11,7 @@ import { filterApplications, getApplicationsByStatus, fetchApplicationsByStatusK
 import { ApplicationData } from '../../types';
 import { getRoleConfig } from '../../config/roles';
 import { PageLayoutSkeleton, TableSkeleton } from '../../components/Skeleton';
-
-import Footer from '@/components/Footer';
+import Footer from '../../components/Footer';
 
 
 

--- a/frontend/src/app/inbox/layout.tsx
+++ b/frontend/src/app/inbox/layout.tsx
@@ -3,12 +3,11 @@
 import React, { Suspense } from 'react';
 import { Sidebar } from '../../components/Sidebar';
 import Header from '../../components/Header';
+import Footer from '../../components/Footer';
 
 import { InboxProvider } from '../../context/InboxContext';
 
 import InboxBootloaderClient from '../../components/InboxBootloaderClient';
-
-import Footer from '../../components/Footer';
 
 
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { getCookie } from 'cookies-next';
 import Image from 'next/image';
 import Link from 'next/link';
+import Footer from '../../components/Footer';
 
 // Type assertions for Next.js components to fix React 18 compatibility
 const ImageFixed = Image as any;
@@ -361,7 +362,7 @@ function LoginContent() {
 
   return (
     <div
-      className="min-h-screen flex items-center justify-center bg-cover bg-center bg-fixed py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden bg-[url('/backgroundIMGALMS.jpeg')]"
+      className="min-h-screen flex flex-col bg-cover bg-center bg-fixed relative overflow-hidden bg-[url('/backgroundIMGALMS.jpeg')]"
       role='main'
     >
       {/* Overlay */}
@@ -369,7 +370,8 @@ function LoginContent() {
         className='absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/50 backdrop-blur-[2px]'
         aria-hidden='true'
       />
-      <div className='relative max-w-md w-full space-y-6 bg-white/90 p-10 rounded-lg shadow-xl backdrop-blur-sm border border-white/40'>
+      <div className='relative flex-grow flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8'>
+        <div className='max-w-md w-full space-y-6 bg-white/90 p-10 rounded-lg shadow-xl backdrop-blur-sm border border-white/40'>
         {/* Header */}
         <div className='flex flex-col items-center'>
           <div className='mb-6'>
@@ -431,6 +433,8 @@ function LoginContent() {
           </div>
         </form>
       </div>
+      </div>
+      <Footer variant="dark" className="relative z-10" />
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -153,8 +153,6 @@ export default function Home() {
 
       </div>
 
-      <Footer />
-
     </div>
 
   );

--- a/frontend/src/app/public/application/[id]/page.tsx
+++ b/frontend/src/app/public/application/[id]/page.tsx
@@ -523,15 +523,6 @@ export default function PublicApplicationPage({ params }: PublicApplicationPageP
           </p>
         </div>
       </main>
-
-      {/* Footer */}
-      <footer className='bg-gray-100 border-t border-gray-200 py-4 mt-8'>
-        <div className='max-w-4xl mx-auto px-4 text-center'>
-          <p className='text-sm text-gray-600'>
-            Arms License Management System (ALMS) - Public Verification Portal
-          </p>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/frontend/src/app/superAdmin/layout.tsx
+++ b/frontend/src/app/superAdmin/layout.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from '@/components/Sidebar';
 import { LayoutProvider } from '@/config/layoutContext';
 import { isAdminRole } from '@/utils/roleUtils';
 import { ROLE_CODES } from '@/constants';
+import Footer from '@/components/Footer';
 
 export default function SuperAdminLayout({ children }: { children: any }) {
   const { userRole, token, isLoading } = useAuthSync();
@@ -66,7 +67,12 @@ export default function SuperAdminLayout({ children }: { children: any }) {
     <LayoutProvider>
       <div className='flex h-screen bg-gray-50'>
         <Sidebar />
-        <main className='flex-1 ml-[80px] md:ml-[18%] min-w-0 overflow-auto'>{children}</main>
+        <main className='flex-1 ml-[80px] md:ml-[18%] min-w-0 overflow-auto flex flex-col'>
+          <div className="flex-grow">
+            {children}
+          </div>
+          <Footer />
+        </main>
       </div>
     </LayoutProvider>
   );

--- a/frontend/src/components/ConditionalFooter.tsx
+++ b/frontend/src/components/ConditionalFooter.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Footer from './Footer';
+
+const ConditionalFooter = () => {
+  const pathname = usePathname();
+
+  // Hide footer on login and public pages
+  const hideFooterRoutes = ['/login', '/reset-password', '/sent'];
+  const shouldHideFooter = hideFooterRoutes.some(route => pathname === route || pathname.startsWith(route));
+
+  if (shouldHideFooter) {
+    return null;
+  }
+
+  return <Footer />;
+};
+
+export default ConditionalFooter;

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,11 +1,35 @@
 import React from 'react';
 
-const Footer: React.FC = () => {
+interface FooterProps {
+  className?: string;
+  showBorder?: boolean;
+  variant?: 'default' | 'light' | 'dark';
+}
+
+const Footer: React.FC<FooterProps> = ({ 
+  className = '', 
+  showBorder = true,
+  variant = 'default'
+}) => {
   const currentYear = new Date().getFullYear();
 
+  const baseClasses = 'w-full text-center text-sm mt-8';
+  
+  const variantClasses = {
+    default: 'text-gray-600 bg-gray-50',
+    light: 'text-gray-500 bg-white',
+    dark: 'text-gray-300 bg-gray-900'
+  };
+
+  const borderClass = showBorder ? 'border-t border-gray-200' : '';
+
   return (
-    <footer className="w-full py-6 text-center text-sm text-gray-500 bg-gray-50 border-t border-gray-200 mt-auto">
-      <p>&copy; {currentYear} ALMS - Arms License Management System. All rights reserved.</p>
+    <footer className={`${baseClasses} ${variantClasses[variant]} ${borderClass} ${className}`}>
+      <div className="max-w-7xl mx-auto px-4">
+        <p className="text-sm">
+          &copy; {currentYear} ALMS - Arms License Management System. All rights reserved.
+        </p>
+      </div>
     </footer>
   );
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1042,6 +1042,18 @@ export const Sidebar = memo(({ onStatusSelect, onTableReload }: SidebarProps = {
   const handleInboxToggle = useCallback(() => {
     try {
       const newState = !isInboxOpen;
+      
+      // When clicking Inbox button (not just toggling), navigate to show all inbox items
+      if (!isInboxOpen) {
+        // Opening inbox - navigate to combined view
+        const activeItemKey = normalizeNavKey('inbox-all');
+        setActiveItem(activeItemKey);
+        persistActiveNavToLocal(activeItemKey);
+        
+        // Navigate to combined inbox view
+        router.push('/inbox?type=all');
+      }
+      
       dispatch(toggleInbox());
       if (typeof window !== 'undefined' && window.localStorage) {
         window.localStorage.setItem('inboxDesiredOpen', newState ? 'true' : 'false');
@@ -1051,7 +1063,7 @@ export const Sidebar = memo(({ onStatusSelect, onTableReload }: SidebarProps = {
         dispatch(toggleInbox());
       } catch (err) {}
     }
-  }, [dispatch, isInboxOpen]);
+  }, [dispatch, isInboxOpen, normalizeNavKey, persistActiveNavToLocal, setActiveItem, router]);
 
   const handleInboxSubItemClick = useCallback(
     (subItem: string) => {


### PR DESCRIPTION
Remove duplicate footer and keep only one footer

Fix footer position at the bottom, aligned after the sidebar

Ensure only one sidebar item is active at a time

Open Inbox dropdown only on dropdown icon click

Trigger API calls only for the active (highlighted) item

Make Inbox act as a combined filter (Forwarded, Returned, Re-enquiry, Red Flag)

Show document image previews similar to biometric/photo previews

Prevent unnecessary API calls