### PR TITLE
fic reject upload document

### DIFF
--- a/frontend/src/app/forms/renewal/page.tsx
+++ b/frontend/src/app/forms/renewal/page.tsx
@@ -4481,6 +4481,7 @@ function RenewalFormPageContent() {
                     onChange={handleChange}
                     onFileChange={handleFileChange}
                     errors={biometricErrors}
+                    isReadOnly={isReadOnly}
                     onPrevious={() => {
                       if (renewalId)
                         router.push(
@@ -4519,6 +4520,7 @@ function RenewalFormPageContent() {
                     onError={setError}
                     onStatus={setStatusMessage}
                     errors={documentsErrors}
+                    isReadOnly={isReadOnly}
                     onReload={reloadRenewalData}
                   />
                 </AccordionSection>

--- a/frontend/src/components/forms/renewal/sections/BiometricInformation.tsx
+++ b/frontend/src/components/forms/renewal/sections/BiometricInformation.tsx
@@ -38,11 +38,12 @@ const BiometricInformation = forwardRef(function BiometricInformation(
     onPrevious?: () => void;
     onNext?: () => void;
     onSaveToDraft?: () => void;
+    isReadOnly?: boolean;
     errors?: ErrorsMap;
   },
   ref,
 ) {
-  const { formData, renewalId, onPrevious, onNext, onSaveToDraft, errors = {} } = props;
+  const { formData, renewalId, onPrevious, onNext, onSaveToDraft, isReadOnly = false, errors = {} } = props;
   const [form, setForm] = useState<BiometricForm>(initialState);
   const [uploadingFiles, setUploadingFiles] = useState(false);
   const [streamActive, setStreamActive] = useState(false);
@@ -615,6 +616,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
         <div>
           <div className='flex justify-between items-center mb-4'>
             <h3 className='text-lg font-semibold text-gray-800'>Signature / Thumb Impression</h3>
+            {!isReadOnly && (
             <div className='flex items-center gap-2'>
               <div className='relative'>
                 <button 
@@ -651,8 +653,11 @@ const BiometricInformation = forwardRef(function BiometricInformation(
                 Settings
               </button>
             </div>
+            )}
           </div>
 
+          {!isReadOnly && (
+          <>
           <FormField 
             label='Select Hand & Finger' 
             required 
@@ -702,6 +707,8 @@ const BiometricInformation = forwardRef(function BiometricInformation(
               </p>
             )}
           </div>
+          </>
+          )}
 
           {enrolledFingerprints.length > 0 && (() => {
             const latestFp = enrolledFingerprints[enrolledFingerprints.length - 1];
@@ -752,7 +759,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
           })()}
         </div>
 
-        {/* Iris Scan Section */}
+        {!isReadOnly && (
         <div>
           <h3 className='text-lg font-semibold text-gray-800 mb-4'>Iris Scan</h3>
           <button 
@@ -771,6 +778,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
             ℹ️ Iris scanning will be available soon. Please check back later for updates.
           </p>
         </div>
+        )}
       </div>
 
       {/* Photograph Section */}
@@ -786,6 +794,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
 
         <div className='grid md:grid-cols-2 gap-6 items-stretch'>
           {/* Webcam & Upload Section */}
+          {!isReadOnly && (
           <div className='flex flex-col justify-between space-y-4 border border-gray-100 rounded-xl p-4 bg-slate-50/50'>
             <div className='space-y-3'>
               <button
@@ -832,6 +841,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
               </label>
             </div>
           </div>
+          )}
 
           {/* Preview Section */}
           <div className='flex flex-col items-center justify-center border border-gray-100 rounded-xl p-4 bg-slate-50/50 min-h-[200px]'>
@@ -850,7 +860,11 @@ const BiometricInformation = forwardRef(function BiometricInformation(
                   </span>
                 </div>
                 
-                {showPhotoDeleteConfirm ? (
+                {isReadOnly ? (
+                  <div className='flex-1 text-center py-2 text-sm font-semibold text-green-600 bg-green-50 rounded-lg border border-green-200 mt-4'>
+                    ✓ Photo Saved
+                  </div>
+                ) : showPhotoDeleteConfirm ? (
                   <div className='mt-3 p-3 bg-red-50 border border-red-200 rounded-lg text-center w-full max-w-[260px] animate-fade-in'>
                     <p className='text-xs font-semibold text-red-700 leading-normal mb-3'>
                       Are you sure you want to delete the photograph? This action cannot be undone.

--- a/frontend/src/components/forms/renewal/sections/DocumentsSection.tsx
+++ b/frontend/src/components/forms/renewal/sections/DocumentsSection.tsx
@@ -29,11 +29,12 @@ const DocumentsSection = forwardRef(function DocumentsSection(
     onError?: (message: string) => void;
     onStatus?: (message: string | null) => void;
     errors?: ErrorsMap;
+    isReadOnly?: boolean;
     onReload?: () => Promise<void>;
   },
   ref: any,
 ) {
-  const { formData, renewalId, onPatch, onError, onStatus, errors = {}, onReload } = props;
+  const { formData, renewalId, onPatch, onError, onStatus, errors = {}, isReadOnly = false, onReload } = props;
   const [uploadingField, setUploadingField] = useState<string | null>(null);
   const [deletingFileId, setDeletingFileId] = useState<number | null>(null);
 
@@ -142,7 +143,7 @@ const DocumentsSection = forwardRef(function DocumentsSection(
                 name={key}
                 required={required}
                 variant='browseCard'
-                onFileSelect={handleSelect(key)}
+                onFileSelect={isReadOnly ? () => {} : handleSelect(key)}
                 uploaded={showUploaded}
                 fileName={
                   isFieldSyncing
@@ -151,7 +152,7 @@ const DocumentsSection = forwardRef(function DocumentsSection(
                     ? 'Uploading...'
                     : meta.fileName
                 }
-                disabled={!renewalId}
+                disabled={!renewalId || isReadOnly}
               />
               {errors[key] && (
                 <p className='text-red-500 text-xs mt-1'>{errors[key]}</p>
@@ -171,7 +172,7 @@ const DocumentsSection = forwardRef(function DocumentsSection(
                         View document
                       </button>
                     )}
-                    {(canDeleteViaApi || (meta.fileUrl && !meta.id)) && (
+                    {!isReadOnly && (canDeleteViaApi || (meta.fileUrl && !meta.id)) && (
                       <button
                         type='button'
                         className='text-red-600 underline hover:text-red-800 disabled:opacity-50'

--- a/frontend/src/services/fileUploadService.ts
+++ b/frontend/src/services/fileUploadService.ts
@@ -80,7 +80,8 @@ export class FileUploadService {
 
   /**
    * Upload actual file to storage and then save metadata
-   * This method handles the full upload process including file storage
+   * This method handles the full upload process — converts the file to a base64
+   * data URL so the stored fileUrl can be displayed directly in the browser.
    */
   static async uploadFileWithStorage(
     applicationId: number,
@@ -89,13 +90,12 @@ export class FileUploadService {
     description?: string
   ): Promise<FileUploadResponse> {
     try {
-      // For now, we'll simulate file upload to storage
-      // In a real implementation, this would upload to S3, Azure Blob, etc.
-      const mockFileUrl = this.generateMockFileUrl(applicationId, file, fileType);
+      // Convert the file to a base64 data URL so it can be rendered inline
+      const base64Url = await this.fileToBase64(file);
 
       const uploadData: FileUploadRequest = {
         fileType,
-        fileUrl: mockFileUrl,
+        fileUrl: base64Url,
         fileName: file.name,
         fileSize: file.size,
         description
@@ -108,17 +108,19 @@ export class FileUploadService {
   }
 
   /**
-   * Generate a mock file URL for demonstration purposes
-   * Uses a configurable base URL to avoid unreachable example.com.
-   * Replace with actual storage URL generation in production.
+   * Convert a File to a base64 data URL string.
    */
-  private static generateMockFileUrl(applicationId: number, file: File, fileType: string): string {
-    const timestamp = Date.now();
-    const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
-    const base =
-      (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_FILE_BASE_URL) ||
-      (typeof window !== 'undefined' ? window.location.origin : '');
-    return `${base}/files/${fileType}_${timestamp}_${sanitizedFileName}`;
+  private static fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        resolve(reader.result as string);
+      };
+      reader.onerror = () => {
+        reject(new Error('Failed to convert file to base64'));
+      };
+      reader.readAsDataURL(file);
+    });
   }
 
   /**


### PR DESCRIPTION
Fixed issue wording for Renewal Application: deleting uploaded documents should not refresh the page because it affects other sections.
Reported Fresh Application issue where REJECTED_LICENSE shows as a broken image and clicking the link gives a 404 error.
Reported printed Application Information issue where REJECTED_LICENSE appears as a broken image in Section 8: Uploaded Documents.
Reported that Renewal Biometric Information and Document Upload sections are still not readable.