### PR TITLE
feat: update renewal/cancellation to use license APIs

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -279,14 +279,14 @@ model FreshLicenseApplicationPersonalDetails {
   isRecommended              Boolean?                                        @default(false)
   aliasPotalNumber           String?
   licenseId                  Int?
-  licenseNumber              String?                                         
-  license                    Licenses?                                       @relation(fields: [licenseId], references: [id])
+  licenseNumber              String?
   biometricData              FLAFBiometricDatas?                             @relation("BiometricData")
   criminalHistories          FLAFCriminalHistories[]                         @relation("CriminalHistories")
   fileUploads                FLAFFileUploads[]                               @relation("FileUploads")
   licenseDetails             FLAFLicenseDetails[]                            @relation("LicenseDetails")
   licenseHistories           FLAFLicenseHistories[]                          @relation("LicenseHistories")
   currentUser                Users?                                          @relation("CurrentApplicationOwner", fields: [currentUserId], references: [id], onDelete: Cascade)
+  license                    Licenses?                                       @relation(fields: [licenseId], references: [id])
   occupationAndBusiness      FLAFOccupationAndBusiness?                      @relation("occupationAndBusinessId", fields: [occupationAndBusinessId], references: [id], onDelete: Cascade)
   permanentAddress           FLAFAddressesAndContactDetails?                 @relation("PermanentAddress", fields: [permanentAddressId], references: [id], onDelete: Cascade)
   presentAddress             FLAFAddressesAndContactDetails?                 @relation("PresentAddress", fields: [presentAddressId], references: [id], onDelete: Cascade)
@@ -301,7 +301,6 @@ model FreshLicenseApplicationPersonalDetails {
   @@index([workflowStatusId])
   @@index([currentUserId])
   @@index([createdAt])
-  @@index([licenseId])
 }
 
 model FLAFAddressesAndContactDetails {
@@ -437,7 +436,7 @@ model FreshLicenseApplicationsFormWorkflowHistories {
 model RenewalFormPersonalDetails {
   id                         Int                                        @id @default(autoincrement())
   acknowledgementNo          String?
-  licenseNumber              String                                     
+  licenseNumber              String                                     @unique
   firstName                  String
   middleName                 String?
   lastName                   String
@@ -445,6 +444,7 @@ model RenewalFormPersonalDetails {
   sex                        Sex
   dateOfBirth                DateTime?
   dobInWords                 String?
+  placeOfBirth               String?
   panNumber                  String?
   aadharNumber               String?
   createdAt                  DateTime                                   @default(now())
@@ -716,8 +716,8 @@ model RangeOffices {
 }
 
 model Licenses {
-  id                         Int                                     @id @default(autoincrement())
-  licenseNumber              String                                  @unique
+  id                         Int                                      @id @default(autoincrement())
+  licenseNumber              String                                   @unique
   almsLicenseId              String?
   issueDate                  DateTime
   firstName                  String
@@ -753,7 +753,7 @@ model Licenses {
   permanentRangeOfficeId     Int?
   occupation                 String?
   officeAddress              String?
-  status                     LicenseStatus                           @default(ACTIVE)
+  status                     LicenseStatus                            @default(ACTIVE)
   cancellationReason         String?
   cancellationDate           DateTime?
   suspendedReason            String?
@@ -763,18 +763,18 @@ model Licenses {
   pdfUrl                     String?
   digitalSignature           String?
   issuedBy                   Int?
-  sourceApplicationId        Int?                                    @unique
+  sourceApplicationId        Int?
   lastModifiedByAppId        Int?
   lastModifiedAppType        String?
-  renewalCount               Int                                     @default(0)
-  createdAt                  DateTime                                @default(now())
-  updatedAt                  DateTime                                @updatedAt
-  cancelFormRequests         CancelFormRequests[]                    @relation("LicensesCancelLog")
-  workflowHistories          LicenseWorkflowHistory[]
-  issuedByUser               Users?                                  @relation("IssuedLicenses", fields: [issuedBy], references: [id])          
-  renewalFormPersonalDetails RenewalFormPersonalDetails[]            @relation("LicensesRenewalLink")
-  endorsedWeapons            WeaponTypeMaster[]                      @relation("LicenseEndorsedWeapons")
+  renewalCount               Int                                      @default(0)
+  createdAt                  DateTime                                 @default(now())
+  updatedAt                  DateTime                                 @updatedAt
+  cancelFormRequests         CancelFormRequests[]                     @relation("LicensesCancelLog")
   freshApplications          FreshLicenseApplicationPersonalDetails[]
+  workflowHistories          LicenseWorkflowHistory[]
+  issuedByUser               Users?                                   @relation("IssuedLicenses", fields: [issuedBy], references: [id])
+  renewalFormPersonalDetails RenewalFormPersonalDetails[]             @relation("LicensesRenewalLink")
+  endorsedWeapons            WeaponTypeMaster[]                       @relation("LicenseEndorsedWeapons")
 
   @@index([aadharNumber])
   @@index([status])

--- a/backend/src/modules/renewal/renewal-form.service.ts
+++ b/backend/src/modules/renewal/renewal-form.service.ts
@@ -29,6 +29,24 @@ export class RenewalFormService {
         );
       }
 
+      // Fetch the almsLicenseId from the Licenses table to populate renewalLicenseId
+      let renewalLicenseId: string | null = null;
+      if (createRequest.licenseId) {
+        const lic = await prisma.licenses.findUnique({
+          where: { id: createRequest.licenseId },
+        });
+        if (lic) {
+          renewalLicenseId = lic.almsLicenseId;
+        }
+      } else if (createRequest.licenseNumber) {
+        const lic = await prisma.licenses.findUnique({
+          where: { licenseNumber: createRequest.licenseNumber },
+        });
+        if (lic) {
+          renewalLicenseId = lic.almsLicenseId;
+        }
+      }
+
       // Generate acknowledgement number
       const acknowledgementNo = `RAF${Date.now()}${Math.floor(Math.random() * 1000)}`;
 
@@ -48,6 +66,7 @@ export class RenewalFormService {
             acknowledgementNo,
             licenseId: createRequest.licenseId,
             licenseNumber: createRequest.licenseNumber,
+            renewalLicenseId,
             firstName: createRequest.firstName,
             middleName: createRequest.middleName,
             lastName: createRequest.lastName,
@@ -1579,6 +1598,8 @@ export class RenewalFormService {
           data: {
             acknowledgementNo,
             licenseNumber,
+            licenseId: freshLicense.licenseId || null,
+            renewalLicenseId: freshLicense.almsLicenseId || null,
             firstName: freshLicense.firstName,
             middleName: freshLicense.middleName || null,
             lastName: freshLicense.lastName,

--- a/frontend/src/api/cancelService.ts
+++ b/frontend/src/api/cancelService.ts
@@ -3,7 +3,7 @@ import { patchData } from './axiosConfig';
 
 export interface CancelFormData {
   id?: number;
-  freshLicenseId: number;
+  licenseId: number;
   applicationType: string;
   cancellationReason: string;
   remarks?: string;
@@ -18,12 +18,13 @@ export interface CancelFormData {
 export class CancelService {
   /**
    * Submit a new cancel request
-   * @param payload { applicationId, applicationType, cancellationReason, remarks }
+   * @param payload { licenseId, applicationType, applicantName, cancellationReason, remarks }
    */
   static async createCancelRequest(payload: {
-    freshLicenseId: number;
+    licenseId: number;
     applicationType: string;
     cancellationReason: string;
+    applicantName: string;
     remarks?: string;
   }): Promise<any> {
     return apiClient.post('/cancel-forms', payload);
@@ -37,15 +38,15 @@ export class CancelService {
     limit?: number;
     status?: string;
     requestedBy?: number;
-    freshLicenseId?: number;
+    licenseId?: number;
   }): Promise<any> {
     const params = new URLSearchParams();
     if (filters?.page) params.append('page', String(filters.page));
     if (filters?.limit) params.append('limit', String(filters.limit));
     if (filters?.status) params.append('status', filters.status);
     if (filters?.requestedBy) params.append('requestedBy', String(filters.requestedBy));
-    if (filters?.freshLicenseId) params.append('freshLicenseId', String(filters.freshLicenseId));
-    
+    if (filters?.licenseId) params.append('licenseId', String(filters.licenseId));
+
     return apiClient.get(`/cancel-forms?${params.toString()}`);
   }
 

--- a/frontend/src/api/renewalService.ts
+++ b/frontend/src/api/renewalService.ts
@@ -11,7 +11,7 @@ export interface RenewalFileUploadRequest {
 
 export interface RenewalFileUploadResponse {
   id: number;
-  applicationId: number;
+  renewalApplicationId: number;
   fileType: string;
   fileName: string;
   fileUrl: string;
@@ -96,17 +96,17 @@ export class RenewalService {
     return apiClient.post('/renewal-forms', payload);
   }
 
-  static async getRenewalForm(applicationId: string | number): Promise<any> {
-    return apiClient.get(`/licenses/${applicationId}`);
+  static async getRenewalForm(renewalId: string | number): Promise<any> {
+    return apiClient.get(`/renewal-forms/${renewalId}`);
   }
 
   static async updateRenewalForm(
-    applicationId: string | number,
+    renewalApplicationId: string | number,
     payload: Record<string, any>,
     options?: { isSubmit?: boolean },
   ): Promise<any> {
     const params = new URLSearchParams();
-    params.append('applicationId', String(applicationId));
+    params.append('applicationId', String(renewalApplicationId));
     if (typeof options?.isSubmit === 'boolean') {
       params.append('isSubmit', String(options.isSubmit));
     }
@@ -114,12 +114,12 @@ export class RenewalService {
   }
 
   static async uploadDocument(
-    applicationId: string | number,
+    renewalApplicationId: string | number,
     fileType: string,
     file: File,
   ): Promise<RenewalFileUploadResponse> {
     const fileUrl = await this.fileToBase64(file);
-    return this.uploadDocumentPayload(applicationId, fileType, {
+    return this.uploadDocumentPayload(renewalApplicationId, fileType, {
       fileUrl,
       fileName: file.name,
       fileSize: file.size,
@@ -127,13 +127,13 @@ export class RenewalService {
   }
 
   static async uploadDocumentPayload(
-    applicationId: string | number,
+    renewalApplicationId: string | number,
     fileType: string,
     payload: Omit<RenewalFileUploadRequest, 'fileType'> | RenewalFileUploadRequest,
   ): Promise<RenewalFileUploadResponse> {
     const payloadFileType = 'fileType' in payload && payload.fileType ? payload.fileType : fileType;
 
-    return apiClient.post(`/renewal-forms/${applicationId}/upload-file`, {
+    return apiClient.post(`/renewal-forms/${renewalApplicationId}/upload-file`, {
       ...payload,
       fileType: this.normalizeFileType(payloadFileType),
     });
@@ -170,7 +170,7 @@ export class RenewalService {
 
   /**
    * Handle workflow action (forward, approve, reject, etc.) on renewal application
-   * @param applicationId - Application ID to perform action on
+   * @param applicationId - Renewal Application ID to perform action on
    * @param actionId - Action ID from Actiones table
    * @param nextUserId - User ID to forward/assign to (required for forward action)
    * @param remarks - Remarks/comments for the action

--- a/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
+++ b/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
@@ -155,15 +155,15 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   const [expandedHistory, setExpandedHistory] = useState<Record<number, boolean>>({});
   const [licenseData, setLicenseData] = useState<LicenseData | null>(null);
   const [licenseLoading, setLicenseLoading] = useState(false);
-  const [originalApplication, setOriginalApplication] = useState<ApplicationData | null>(null);
-  const [activeTab, setActiveTab] = useState<'original' | 'license'>('original');
+  const [activeTab, setActiveTab] = useState<'info' | 'original'>('info');
   const [rawRenewalData, setRawRenewalData] = useState<any | null>(null);
-  const [freshApplicationForLicense, setFreshApplicationForLicense] =
-    useState<ApplicationData | null>(null);
-  const [freshLoading, setFreshLoading] = useState(false);
-  const [freshApplicationHistory, setFreshApplicationHistory] = useState<any[]>([]);
-  const [freshHistoryLoading, setFreshHistoryLoading] = useState(false);
-  const [expandedFreshHistory, setExpandedFreshHistory] = useState<Record<number, boolean>>({});
+  // Original License Details tab: loaded via the License GET API only (no fresh-app API).
+  const [originalLicenseData, setOriginalLicenseData] = useState<LicenseData | null>(null);
+  const [originalLicenseLoading, setOriginalLicenseLoading] = useState(false);
+  const originalLicenseLoadedIdRef = useRef<string | number | null>(null);
+  // Application History for the Original License tab, sourced from the Workflow History API.
+  const [originalLicenseHistory, setOriginalLicenseHistory] = useState<any[]>([]);
+  const originalLicenseHistoryLoadedIdRef = useRef<string | number | null>(null);
   const printRef = useRef<HTMLDivElement>(null);
   const [dividerPosition, setDividerPosition] = useState(66.66); // Left section percentage (2 of 3 columns)
   const [isDragging, setIsDragging] = useState(false);
@@ -175,15 +175,15 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
   useEffect(() => {
     const tab = searchParams?.get('tab');
-    setActiveTab(tab === 'original' ? 'license' : 'original');
+    setActiveTab(tab === 'original' ? 'original' : 'info');
   }, [searchParams]);
 
   const handleTabChange = (tab: string) => {
     const isOriginalTab = tab === 'Original License Details' || tab === 'original';
-    const nextTab = isOriginalTab ? 'license' : 'original';
+    const nextTab: 'info' | 'original' = isOriginalTab ? 'original' : 'info';
     setActiveTab(nextTab);
     const params = new URLSearchParams(searchParams?.toString() || '');
-    params.set('tab', isOriginalTab ? 'original' : 'info');
+    params.set('tab', nextTab);
     router.replace(`${pathname}?${params.toString()}`);
   };
 
@@ -193,14 +193,11 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   const { refreshCounts } = useSidebarCounts(!loading);
   const { executeAction, setActiveNavigationPath } = useGlobalAction();
   const currentDisplayApp = useMemo(() => {
-    if (isRenewalView && activeTab === 'original' && originalApplication) {
-      return originalApplication;
-    }
-    if (isRenewalView && activeTab === 'license' && freshApplicationForLicense) {
-      return freshApplicationForLicense;
+    if (isRenewalView && activeTab === 'original' && originalLicenseData) {
+      return originalLicenseData as unknown as ApplicationData;
     }
     return application;
-  }, [isRenewalView, activeTab, originalApplication, application, freshApplicationForLicense]);
+  }, [isRenewalView, activeTab, originalLicenseData, application]);
 
   const licenseDetails = useMemo(() => {
     const rawDetails =
@@ -220,9 +217,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   }, [currentDisplayApp]);
 
   const showFullApplicationDetails =
-    !isRenewalView ||
-    activeTab === 'original' ||
-    (isRenewalView && activeTab === 'license' && freshApplicationForLicense !== null);
+    !isRenewalView || activeTab === 'info' || activeTab === 'original';
 
   // Handle params Promise for React 18 compatibility
   useEffect(() => {
@@ -259,36 +254,6 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
           if (renewalData) {
             setRawRenewalData(renewalData);
             setApplication(normalizeRenewalApplication(renewalData));
-
-            // Fetch original/linked application details (freshApplicationId fallback)
-            const linkedId =
-              renewalData.freshApplicationId ||
-              renewalData.applicationId ||
-              renewalData.sourceApplicationId;
-            if (linkedId) {
-              try {
-                const origResult = await getApplicationByApplicationId(String(linkedId));
-                if (origResult) {
-                  setOriginalApplication(origResult as ApplicationData);
-                }
-              } catch (err) {
-                console.error('Failed to fetch original application', err);
-              }
-            }
-
-            // Preload fresh license's application if freshLicenseId present
-            const freshLicenseId = renewalData.freshLicenseId || null;
-            if (freshLicenseId) {
-              try {
-                setFreshLoading(true);
-                const freshApp = await getApplicationByApplicationId(String(freshLicenseId));
-                if (freshApp) setFreshApplicationForLicense(freshApp as ApplicationData);
-              } catch (err) {
-                console.error('Failed to fetch fresh license application', err);
-              } finally {
-                setFreshLoading(false);
-              }
-            }
           } else {
             setApplication(null);
           }
@@ -361,78 +326,72 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
     }
   }, [applicationId, isRenewalView]);
 
-  // When user switches to the license tab, fetch fresh license application if not preloaded
+  // When user opens the "Original License Details" tab:
+  // 1. Call the License GET API (using the licenseId from the Renewal Application) once.
+  // 2. From the License response, read `sourceApplicationId` and `lastModifiedAppType`
+  //    and call the Workflow History API with those values — this populates the
+  //    Application History section. No Fresh Application API is used.
+  // Both APIs run only once per license when the tab is opened (duplicate calls avoided).
   useEffect(() => {
-    const fetchFreshForLicense = async () => {
-      if (!isRenewalView || activeTab !== 'license') return;
-      // Prefer explicit freshLicenseId from renewal payload, fallback to freshApplicationId or linked ids
-      const freshLicenseId =
-        (rawRenewalData && (rawRenewalData.freshLicenseId || rawRenewalData.freshApplicationId)) ||
-        (rawRenewalData && rawRenewalData.applicationId) ||
-        (rawRenewalData && rawRenewalData.sourceApplicationId) ||
-        null;
-      if (!freshLicenseId) return;
+    const fetchOriginalLicense = async () => {
+      if (!isRenewalView || activeTab !== 'original') return;
 
-      // If already loaded, skip
-      if (
-        freshApplicationForLicense &&
-        String(freshApplicationForLicense.id) === String(freshLicenseId)
-      ) {
-        // But still try to fetch history if not already loaded
-        if (freshApplicationHistory.length === 0) {
-          try {
-            setFreshHistoryLoading(true);
-            const historyResponse = await apiClient.get<any>(
-              `/workflow/history/${freshLicenseId}?type=fresh`
-            );
-            if (historyResponse && historyResponse.success) {
-              setFreshApplicationHistory(historyResponse.data);
-            }
-          } catch (err) {
-            console.error('Failed to fetch fresh application workflow history', err);
-          } finally {
-            setFreshHistoryLoading(false);
-          }
-        }
-        return;
-      }
+      // Derive the license id from the renewal record.
+      const licenseId =
+        rawRenewalData?.licenseId ??
+        rawRenewalData?.renewalLicenseId ??
+        rawRenewalData?.almsLicenseId ??
+        null;
+      if (!licenseId) return;
+
+      // Avoid duplicate License GET API requests for the same license.
+      if (String(licenseId) === String(originalLicenseLoadedIdRef.current)) return;
+      originalLicenseLoadedIdRef.current = licenseId;
 
       try {
-        setFreshLoading(true);
-        const freshApp = await getApplicationByApplicationId(String(freshLicenseId));
-        if (freshApp) {
-          setFreshApplicationForLicense(freshApp as ApplicationData);
+        setOriginalLicenseLoading(true);
+        const license = await LicenseService.getLicenseById(Number(licenseId));
+        if (!license) {
+          setOriginalLicenseData(null);
+          setOriginalLicenseHistory([]);
+          return;
+        }
+        setOriginalLicenseData(license);
 
-          // Fetch workflow history for fresh application
-          try {
-            setFreshHistoryLoading(true);
-            const historyResponse = await apiClient.get<any>(
-              `/workflow/history/${freshLicenseId}?type=fresh`
-            );
-            if (historyResponse && historyResponse.success) {
-              setFreshApplicationHistory(historyResponse.data);
+        // Now call the Workflow History API using the License's sourceApplicationId
+        // and lastModifiedAppType. Avoid duplicate calls for the same license.
+        if (String(licenseId) !== String(originalLicenseHistoryLoadedIdRef.current)) {
+          originalLicenseHistoryLoadedIdRef.current = licenseId;
+          setOriginalLicenseHistory([]);
+          const sourceApplicationId =
+            license.sourceApplicationId ?? (license as any).sourceAppId ?? null;
+          const lastModifiedAppType =
+            license.lastModifiedAppType ?? (license as any).lastModifiedAppTypeId ?? 'FRESH';
+          if (sourceApplicationId) {
+            try {
+              const historyResponse = await apiClient.get<any>(
+                `/workflow/history/${sourceApplicationId}?type=${lastModifiedAppType}`
+              );
+              if (historyResponse && historyResponse.success) {
+                setOriginalLicenseHistory(historyResponse.data);
+              } else if (Array.isArray(historyResponse)) {
+                setOriginalLicenseHistory(historyResponse);
+              }
+            } catch (historyErr) {
+              console.error('Failed to fetch original license workflow history', historyErr);
+              setOriginalLicenseHistory([]);
             }
-          } catch (err) {
-            console.error('Failed to fetch fresh application workflow history', err);
-          } finally {
-            setFreshHistoryLoading(false);
           }
         }
       } catch (err) {
-        console.error('Failed to fetch fresh license application on tab change', err);
+        console.error('Failed to fetch original license on tab change', err);
       } finally {
-        setFreshLoading(false);
+        setOriginalLicenseLoading(false);
       }
     };
 
-    fetchFreshForLicense();
-  }, [
-    activeTab,
-    isRenewalView,
-    rawRenewalData,
-    freshApplicationForLicense,
-    freshApplicationHistory,
-  ]);
+    fetchOriginalLicense();
+  }, [activeTab, isRenewalView, rawRenewalData]);
 
   // Clear success message after 5 seconds
   useEffect(() => {
@@ -844,8 +803,8 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
               acknowledgementNo={application.acknowledgementNo}
               activeTab={
                 activeTab === 'original'
-                  ? 'Renewal Application Info'
-                  : 'Original License Details'
+                  ? 'Original License Details'
+                  : 'Renewal Application Info'
               }
               onTabChange={handleTabChange}
             />
@@ -868,31 +827,6 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                 const application = displayApp;
                 return (
                   <div className='p-6 lg:p-8 space-y-8 bg-slate-50/30' ref={printRef}>
-                    {/* Tab Selection for Renewal */}
-                    {isRenewalView && originalApplication && (
-                      <div className='flex border-b border-slate-200 mt-2 mb-6 print:hidden'>
-                        <button
-                          onClick={() => handleTabChange('info')}
-                          className={`py-3 px-6 font-semibold text-sm transition-all border-b-2 -mb-[2px] ${
-                            activeTab === 'original'
-                              ? 'border-blue-600 text-blue-600'
-                              : 'border-transparent text-slate-500 hover:text-slate-800'
-                          }`}
-                        >
-                          Renewal Application Details
-                        </button>
-                        <button
-                          onClick={() => handleTabChange('original')}
-                          className={`py-3 px-6 font-semibold text-sm transition-all border-b-2 -mb-[2px] ${
-                            activeTab === 'license'
-                              ? 'border-blue-600 text-blue-600'
-                              : 'border-transparent text-slate-500 hover:text-slate-800'
-                          }`}
-                        >
-                          Original License Details
-                        </button>
-                      </div>
-                    )}
                     {showFullApplicationDetails && (
                       <>
                         {/* 1. Application Information Section */}
@@ -1895,7 +1829,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                     }}
                   >
                     {/* Action Buttons - Full Width Editor (2 columns) - Hidden on License Tab */}
-                    {!(isRenewalView && activeTab === 'license') && (
+                    {!(isRenewalView && activeTab === 'original') && (
                     <div
                       className='flex flex-col h-full overflow-hidden pr-4'
                       style={{
@@ -1914,18 +1848,18 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                       <div className='flex flex-col gap-4 flex-1 overflow-hidden'>
                         {(() => {
                           // Determine which application to use based on active tab
-                          const displayApp =
-                            isRenewalView && activeTab === 'license'
-                              ? freshApplicationForLicense
+                          const displayApp: ApplicationData | null =
+                            isRenewalView && activeTab === 'original'
+                              ? (originalLicenseData as unknown as ApplicationData)
                               : application;
                           const displayAppId =
-                            isRenewalView && activeTab === 'license'
-                              ? freshApplicationForLicense?.id
+                            isRenewalView && activeTab === 'original'
+                              ? originalLicenseData?.id
                               : applicationId;
                           const isLoading =
-                            isRenewalView && activeTab === 'license' && freshLoading;
+                            isRenewalView && activeTab === 'original' && originalLicenseLoading;
                           const isNotAvailable =
-                            isRenewalView && activeTab === 'license' && !freshApplicationForLicense;
+                            isRenewalView && activeTab === 'original' && !originalLicenseLoading && !originalLicenseData;
 
                           // If on license tab and still loading, show loading state
                           if (isLoading) {
@@ -1933,15 +1867,15 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                               <div className='bg-white rounded-xl border border-gray-200 shadow-sm h-full overflow-hidden flex flex-col items-center justify-center'>
                                 <div className='flex flex-col items-center gap-3'>
                                   <div className='w-8 h-8 border-4 border-blue-100 border-t-blue-600 rounded-full animate-spin'></div>
-                                  <p className='text-sm text-gray-600'>
-                                    Loading Fresh Application...
-                                  </p>
+                                   <p className='text-sm text-gray-600'>
+                                     Loading License...
+                                   </p>
                                 </div>
                               </div>
                             );
                           }
 
-                          // If on license tab and fresh app not available, show message
+                          // If on license tab and license not available, show message
                           if (isNotAvailable) {
                             return (
                               <div className='bg-yellow-50 border-l-4 border-yellow-400 p-6 rounded-lg shadow-sm'>
@@ -1961,7 +1895,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                                   </svg>
                                   <div>
                                     <h4 className='text-lg font-semibold text-yellow-800 mb-2'>
-                                      Fresh Application Not Available
+                                      License Details Not Available
                                     </h4>
                                     <p className='text-sm text-yellow-700'>
                                       The fresh application details could not be loaded. Please
@@ -2067,7 +2001,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                     )}
 
                     {/* Resizable Divider - Hidden on License Tab */}
-                    {!(isRenewalView && activeTab === 'license') && (
+                    {!(isRenewalView && activeTab === 'original') && (
                     <div
                       ref={dividerRef}
                       onMouseDown={handleDividerMouseDown}
@@ -2084,9 +2018,9 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
                     {/* Application Timeline/History - Right Side with Scroll */}
                     <div
-                      className={`flex flex-col h-full overflow-hidden ${isRenewalView && activeTab === 'license' ? '' : 'pl-4'}`}
+                      className={`flex flex-col h-full overflow-hidden ${isRenewalView && activeTab === 'original' ? '' : 'pl-4'}`}
                       style={{
-                        width: isRenewalView && activeTab === 'license' ? '100%' : `${100 - dividerPosition}%`,
+                        width: isRenewalView && activeTab === 'original' ? '100%' : `${100 - dividerPosition}%`,
                         transition: isDragging ? 'none' : 'width 0.1s ease',
                       }}
                     >
@@ -2099,25 +2033,27 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
                       <div className='flex-1 bg-white rounded-xl border border-gray-200 shadow-sm h-full overflow-hidden'>
                         <div className='overflow-y-auto p-6 custom-scrollbar h-full'>
-                          {isRenewalView && activeTab === 'license' && freshHistoryLoading ? (
+                          {isRenewalView && activeTab === 'original' && originalLicenseLoading ? (
                             <div className='flex flex-col items-center justify-center h-full'>
                               <div className='w-8 h-8 border-4 border-green-100 border-t-green-600 rounded-full animate-spin mb-3'></div>
-                              <p className='text-sm text-gray-600'>Loading history...</p>
+                              <p className='text-sm text-gray-600'>Loading license history...</p>
                             </div>
                           ) : null}
                           {(() => {
-                            // Use fresh app history when on license tab, otherwise use renewal app history
+                            // Use the Workflow History API response (from the Original License's
+                            // sourceApplicationId + lastModifiedAppType) when on the original tab,
+                            // otherwise use the renewal application's workflow history.
                             const historyToShow =
-                              isRenewalView && activeTab === 'license'
-                                ? freshApplicationHistory
+                              isRenewalView && activeTab === 'original'
+                                ? originalLicenseHistory
                                 : application?.workflowHistories;
                             const expandedHistoryMap =
-                              isRenewalView && activeTab === 'license'
-                                ? expandedFreshHistory
+                              isRenewalView && activeTab === 'original'
+                                ? expandedHistory
                                 : expandedHistory;
                             const setExpandedHistoryMap =
-                              isRenewalView && activeTab === 'license'
-                                ? setExpandedFreshHistory
+                              isRenewalView && activeTab === 'original'
+                                ? setExpandedHistory
                                 : setExpandedHistory;
 
                             return historyToShow && historyToShow.length > 0 ? (

--- a/frontend/src/app/application/components/RedesignedComponents.tsx
+++ b/frontend/src/app/application/components/RedesignedComponents.tsx
@@ -216,6 +216,7 @@ export function DocumentTable({ documents }: { documents: any[] }) {
             <tr>
               <th className='px-6 py-4'>Document Type</th>
               <th className='px-6 py-4'>File Name</th>
+              <th className='px-6 py-4'>Uploaded On</th>
               <th className='px-6 py-4 text-right print:hidden'>Actions</th>
             </tr>
           </thead>
@@ -231,6 +232,8 @@ export function DocumentTable({ documents }: { documents: any[] }) {
                 String(doc.type || '')
                   .toLowerCase()
                   .includes('image') || /\.(png|jpe?g|gif|svg|webp)$/.test(docName.toLowerCase());
+              const uploadDate = doc.uploadedAt || doc.createdAt || doc.date;
+              const dateStr = uploadDate ? new Date(uploadDate).toLocaleDateString('en-IN', { year: 'numeric', month: 'short', day: 'numeric' }) : '-';
 
               return (
                 <tr key={idx} className='hover:bg-slate-50/80 transition-colors'>
@@ -250,6 +253,7 @@ export function DocumentTable({ documents }: { documents: any[] }) {
                   >
                     {docName}
                   </td>
+                  <td className='px-6 py-4 text-slate-500 font-medium whitespace-nowrap'>{dateStr}</td>
                   <td className='px-6 py-4 text-right whitespace-nowrap print:hidden'>
                     <div className='inline-flex gap-2'>
                       <button

--- a/frontend/src/app/cancelForm/[id]/CancelFormDetailClient.tsx
+++ b/frontend/src/app/cancelForm/[id]/CancelFormDetailClient.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useRouter, useSearchParams, usePathname } from 'next/navigation';
 import CancelRequestDetail from '@/components/cancelForm/CancelRequestDetail';
-import { getApplicationByApplicationId } from '@/services/sidebarApiCalls';
 import ProceedingsForm from '@/components/ProceedingsForm';
 import CancelService from '@/api/cancelService';
 import { useAuth } from '@/hooks/useAuth';
@@ -13,9 +12,8 @@ import { formatStatusLabel } from '@/utils/formatters';
 import { truncateFilename } from '@/utils/string';
 import { openAttachment } from '@/utils/attachmentViewer';
 import { RichTextDisplay } from '@/components/RichTextDisplay';
-import { Loader2, History, Clock, ChevronDown, FileText } from 'lucide-react';
+import { History, Clock, ChevronDown, FileText, Shield } from 'lucide-react';
 
-const LoaderFixed = Loader2 as any;
 const ClockIcon = Clock as any;
 const ChevronDownIcon = ChevronDown as any;
 
@@ -41,9 +39,13 @@ export default function CancelFormDetailClient() {
   const [error, setError] = useState('');
   const [expandedHistory, setExpandedHistory] = useState<Record<number, boolean>>({});
 
-  const [freshApplication, setFreshApplication] = useState<any>(null);
-  const [freshLoading, setFreshLoading] = useState(false);
+  const [cancelInfoLoading, setCancelInfoLoading] = useState(false);
+
   const [activeTab, setActiveTab] = useState<'info' | 'original'>('info');
+
+  // Tracks which tabs have already triggered their one-time fetch to prevent
+  // duplicate API calls caused by re-renders or repeated state updates.
+  const loadedTabs = React.useRef<{ info?: boolean; original?: boolean }>({});
 
   const [dividerPosition, setDividerPosition] = useState(66.66); // Left section percentage
   const [isDragging, setIsDragging] = useState(false);
@@ -84,53 +86,55 @@ export default function CancelFormDetailClient() {
     };
   }, [isDragging]);
 
-  const fetchRequest = async () => {
+  // Fetch the Cancellation Info data from GET /api/cancel-forms/:id.
+  // This ONLY calls the Cancellation API. The linked license (Original tab)
+  // is fetched separately and lazily when that tab is opened, using the
+  // licenseId returned by this response.
+  const fetchCancelInfo = async (options?: { replaceRequestOnly?: boolean }) => {
     try {
-      setLoading(true);
+      setCancelInfoLoading(true);
       const res = await CancelService.getCancelRequestById(Number(id));
       // Backend wraps response as { success, message, data }
       const reqData = res?.data || res;
       // Guard: only set request state if we actually got a record with a valid id
       if (!reqData || !reqData.id) {
-        setError(`Cancel request #${id} not found.`);
+        if (!options?.replaceRequestOnly) setError(`Cancel request #${id} not found.`);
         return;
       }
       setRequest({
         ...reqData,
         applicationType: 'CancelFormRequest',
       });
-
-      // Try to set any embedded fresh application payload
-      const freshPayload =
-        reqData.freshLicense || reqData.freshApplication || reqData.fresh_application;
-      if (freshPayload) {
-        setFreshApplication(freshPayload);
-      } else {
-        const linkedId =
-          reqData.freshLicenseId || reqData.freshApplicationId || reqData.fresh_license_id;
-        if (linkedId) {
-          try {
-            setFreshLoading(true);
-            const fetched = await getApplicationByApplicationId(String(linkedId));
-            if (fetched) setFreshApplication(fetched);
-          } catch (err) {
-            console.error('Failed to fetch linked fresh application', err);
-          } finally {
-            setFreshLoading(false);
-          }
-        }
-      }
     } catch (err) {
       console.error('Fetch error:', err);
-      setError(`Cancel request #${id} was not found or could not be loaded.`);
+      if (!options?.replaceRequestOnly) {
+        setError(`Cancel request #${id} was not found or could not be loaded.`);
+      }
     } finally {
-      setLoading(false);
+      setCancelInfoLoading(false);
     }
   };
 
+  // Initial load: fetch the Cancellation Info (GET /api/cancel-forms/:id) once.
+  // The response is needed for both tabs (the Original tab reads licenseId from it).
   useEffect(() => {
-    if (id) fetchRequest();
+    if (id) {
+      setLoading(true);
+      loadedTabs.current.info = true;
+      fetchCancelInfo().finally(() => setLoading(false));
+    }
   }, [id]);
+
+  // Lazy load the Original License Details tab (GET /api/licenses/:licenseId).
+  // Called only once, and only when the Original tab is opened, using the
+  // licenseId returned by the Cancellation API. No Fresh Application API is used.
+  const [originalLoaded, setOriginalLoaded] = useState(false);
+  useEffect(() => {
+    if (activeTab === 'original' && request?.licenseId && !loadedTabs.current.original) {
+      loadedTabs.current.original = true;
+      setOriginalLoaded(true);
+    }
+  }, [activeTab, request?.licenseId]);
 
   useEffect(() => {
     const tab = searchParams?.get('tab');
@@ -138,7 +142,7 @@ export default function CancelFormDetailClient() {
   }, [searchParams]);
 
   const handleTabChange = (tab: string) => {
-    const nextTab = tab === 'Original Application Details' ? 'original' : 'info';
+    const nextTab = tab === 'License Details' ? 'original' : 'info';
     setActiveTab(nextTab);
     const params = new URLSearchParams(searchParams?.toString() || '');
     params.set('tab', nextTab);
@@ -173,23 +177,44 @@ export default function CancelFormDetailClient() {
   }, [id, request, router, setHeaderOptions]);
 
   const handleProceedingsSuccess = (message?: string) => {
-    fetchRequest(); // Reload details
+    fetchCancelInfo({ replaceRequestOnly: true }); // Reload details
   };
 
   if (loading) {
     return (
-      <div className='flex justify-center items-center h-screen bg-slate-50'>
-        <LoaderFixed className='w-8 h-8 animate-spin text-red-600 mr-3' />
-        <span className='text-xl font-medium text-gray-700'>Loading request...</span>
+      <div className='min-h-screen bg-slate-50 flex items-center justify-center px-4'>
+        <div className='rounded-2xl bg-white px-8 py-10 shadow-lg border border-slate-200 text-center'>
+          <div className='mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-slate-200 border-t-blue-700' />
+          <p className='text-slate-600'>Loading cancellation request…</p>
+        </div>
       </div>
     );
   }
 
   if (error || !request) {
     return (
-      <div className='p-8 bg-slate-50 min-h-screen'>
-        <div className='bg-red-50 text-red-700 p-6 rounded-lg text-center font-medium max-w-2xl mx-auto shadow-sm border border-red-100'>
-          {error || 'Request not found'}
+      <div className='min-h-screen bg-slate-50 flex items-center justify-center px-4'>
+        <div className='max-w-md rounded-2xl bg-white p-8 shadow-lg border border-slate-200 text-center'>
+          <h1 className='text-2xl font-bold text-slate-900'>Cancellation Request Not Found</h1>
+          <p className='mt-3 text-slate-600'>
+            {error || 'The selected cancellation request could not be loaded.'}
+          </p>
+          <div className='mt-6 flex flex-wrap justify-center gap-3'>
+            <button
+              type='button'
+              onClick={() => router.back()}
+              className='rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50'
+            >
+              Go Back
+            </button>
+            <button
+              type='button'
+              onClick={() => router.push('/inbox?type=all')}
+              className='rounded-lg bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800'
+            >
+              Back to Applications
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -207,18 +232,21 @@ export default function CancelFormDetailClient() {
   const showApplicationProcessingSection = activeTab === 'info';
 
   return (
-    <div className='flex flex-col min-h-screen w-full bg-gray-50 font-[family-name:var(--font-geist-sans)]'>
-      <main className='flex-1 overflow-y-auto w-full'>
-        <div className=''>
-          <div className='py-6 lg:py-8 space-y-6'>
+    <div className='min-h-screen bg-slate-50 font-[family-name:var(--font-geist-sans)]'>
+      <main className='w-full'>
+        <div className='w-full'>
+          <div className='space-y-6'>
             <CancelRequestDetail
               request={request}
-              freshApplication={freshApplication}
+              licenseId={request.licenseId}
+              licenseNumber={request.licenseNumber}
               activeTab={activeTab}
               onTabChange={handleTabChange}
+              loading={cancelInfoLoading}
+              loadOriginal={originalLoaded}
             />
 
-            <div className='rounded-xl border border-gray-200 shadow-sm bg-white overflow-hidden print:hidden'>
+            <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden print:hidden'>
               <div className='p-4 lg:p-4 border-t border-gray-100'>
                 <div
                   ref={containerRef}
@@ -315,7 +343,7 @@ export default function CancelFormDetailClient() {
                     <div className='flex items-center justify-between mb-4'>
                       <h3 className='text-lg font-semibold text-gray-900 flex items-center'>
                         <div className='w-1 h-5 bg-red-600 rounded-full mr-3'></div>
-                        Cancellation History
+                        Application History
                       </h3>
                     </div>
 

--- a/frontend/src/app/cancelForm/layout.tsx
+++ b/frontend/src/app/cancelForm/layout.tsx
@@ -54,8 +54,8 @@ export default function CancelFormLayout({ children }: { children: React.ReactNo
       <Header hideCreateForm {...headerOptions} />
 
       {/* Main content area — full width when sidebar is removed */}
-      <div className='flex-1 overflow-y-auto ml-0 mt-[64px] md:mt-[70px] flex flex-col'>
-        <div className='flex-grow p-6 md:p-8 max-w-[1200px] mx-auto w-full'>
+      <div className='w-full mt-[64px]'>
+        <div className='w-full p-6'>
           <div className='w-full'>{children}</div>
         </div>
         <Footer />

--- a/frontend/src/app/forms/renewal/page.tsx
+++ b/frontend/src/app/forms/renewal/page.tsx
@@ -31,9 +31,7 @@ import BiometricAPIService from '../../../services/biometricAPIService';
 
 type RenewalFormState = {
   renewalApplicationId: string;
-  applicationId: string;
-  licenseId?: number;
-  freshLicenseId?: number;
+  licenseId: string | number;
   licenseNumber: string;
   acknowledgementNo: string;
   applicantName: string;
@@ -172,9 +170,7 @@ type RenewalFormState = {
 
 const initialFormState: RenewalFormState = {
   renewalApplicationId: '',
-  applicationId: '',
-  licenseId: undefined,
-  freshLicenseId: undefined,
+  licenseId: '',
   licenseNumber: '',
   acknowledgementNo: '',
   applicantName: '',
@@ -356,6 +352,7 @@ const getLicenseNumber = (data: any) =>
     data?.licenseHistory?.[0]?.previousLicenseNumber,
     data?.previousApplicationDetails?.previousLicenseNumber
   );
+
 
 /** Split combined applicantName when API omits firstName/middleName/lastName */
 const parseApplicantNameParts = (fullName: string) => {
@@ -974,33 +971,20 @@ const getUploadedFiles = (data: any) => collectUploadedFilesFromApi(data);
 
 const hasSavedDocuments = (data: any) => getUploadedFiles(data).length > 0;
 
-const resolveFreshApplicationId = (renewalData: any, urlApplicationId: string) =>
+const resolveLicenseId = (renewalData: any, urlLicenseId: string) =>
   getTextValue(
-    urlApplicationId,
-    renewalData?.applicationId,
-    renewalData?.freshApplicationId,
-    renewalData?.sourceApplicationId
+    urlLicenseId,
+    renewalData?.licenseId,
+    renewalData?.id
   );
 
-const fetchFreshApplicationWithFiles = async (applicationId: string) => {
-  if (!applicationId) return null;
+const fetchFreshApplicationWithFiles = async (licenseId: string) => {
+  if (!licenseId) return null;
 
-  const freshResponse = await ApplicationService.getLicense(applicationId);
+  const freshResponse = await ApplicationService.getLicense(licenseId);
   console.log(freshResponse)
   let freshData = extractData(freshResponse);
-  if (!freshData) return null;
-
-  if (!collectUploadedFilesFromApi(freshData).length) {
-    try {
-      const files = await FileUploadService.getFiles(applicationId);
-      if (Array.isArray(files) && files.length) {
-        freshData = { ...freshData, fileUploads: files };
-      }
-    } catch (fileErr) {
-      console.warn('Unable to load fresh application file uploads', fileErr);
-    }
-  }
-
+  
   return freshData;
 };
 
@@ -1042,7 +1026,7 @@ const mergeRenewalStateOverFresh = (
   const merged: RenewalFormState = { ...fresh, ...renewal };
 
   merged.renewalApplicationId = renewal.renewalApplicationId || fresh.renewalApplicationId;
-  merged.applicationId = renewal.applicationId || fresh.applicationId;
+  merged.licenseId = renewal.licenseId || fresh.licenseId;
   merged.licenseNumber = renewal.licenseNumber || fresh.licenseNumber;
   merged.acknowledgementNo = renewal.acknowledgementNo || fresh.acknowledgementNo;
 
@@ -1482,7 +1466,7 @@ const mapDocumentUploadFields = (data: any, renewalFileIds?: ReadonlySet<number>
 };
 
 const buildFieldStateFromFreshApplication = (
-  applicationId: string,
+  licenseId: string,
   data: any
 ): RenewalFormState => {
   const firstName = getTextValue(
@@ -1512,8 +1496,7 @@ const buildFieldStateFromFreshApplication = (
 
   return {
     ...initialFormState,
-    applicationId,
-    freshLicenseId: typeof data?.id === 'number' ? data.id : (data?.id ? Number(data.id) : undefined),
+    licenseId: data?.licenseId ? Number(data.licenseId) : (data?.id ? Number(data.id) : undefined) || licenseId,
     licenseNumber: getLicenseNumber(data),
     acknowledgementNo: getTextValue(
       data?.acknowledgementNo,
@@ -1632,8 +1615,7 @@ const buildFieldStateFromFreshApplication = (
 };
 
 const buildRenewalPayload = (formData: RenewalFormState) => ({
-  ...(formData.freshLicenseId !== undefined && { freshLicenseId: formData.freshLicenseId }),
-  ...(formData.licenseId !== undefined && { licenseId: formData.licenseId }),
+  ...(formData.licenseId && { licenseId: Number(formData.licenseId) }),
   licenseNumber: formData.licenseNumber,
   acknowledgementNo: formData.acknowledgementNo,
   firstName: formData.applicantName,
@@ -1956,7 +1938,7 @@ const buildRenewalPatchPayload = (formData: RenewalFormState) => {
   };
 
   // Include licenseId/licenseNumber on the parent record if available
-  if (formData.licenseId !== undefined) {
+  if (formData.licenseId) {
     payload.licenseId = formData.licenseId;
   }
   if (formData.licenseNumber) {
@@ -1973,13 +1955,7 @@ const buildRootDataFromRenewal = (data: any): RenewalFormState => {
   return {
     ...initialFormState,
     renewalApplicationId: getTextValue(data?.id, data?.renewalApplicationId),
-    applicationId: getTextValue(
-      data?.applicationId,
-      data?.freshApplicationId,
-      data?.sourceApplicationId
-    ),
-    licenseId: data?.licenseId !== undefined ? Number(data.licenseId) : undefined,
-    freshLicenseId: data?.freshLicenseId ? Number(data.freshLicenseId) : undefined,
+    licenseId: data?.licenseId ? Number(data.licenseId) : '',
     licenseNumber: getTextValue(data?.licenseNumber),
     acknowledgementNo: getTextValue(data?.acknowledgementNo, personalDetails?.acknowledgementNo),
     ...nameFields,
@@ -2023,14 +1999,14 @@ const buildRootDataFromRenewal = (data: any): RenewalFormState => {
   };
 };
 
-const buildFormDataFromRenewalRecord = async (renewalData: any, _applicationId: string) => {
+const buildFormDataFromRenewalRecord = async (renewalData: any, _licenseId: string) => {
   // When a renewal record exists, use it as the sole source of truth.
   // Do NOT fetch fresh application data — renewal data takes full precedence.
   return buildRootDataFromRenewal(renewalData);
 };
 
 const loadExistingRenewalByLicenseNumber = async (
-  applicationId: string,
+  licenseId: string,
   licenseNumber: string,
   setRenewalRecord: React.Dispatch<React.SetStateAction<any>>,
   setFormData: React.Dispatch<React.SetStateAction<RenewalFormState>>,
@@ -2054,7 +2030,7 @@ const loadExistingRenewalByLicenseNumber = async (
 
   createdRenewalIdRef.current = existingRenewalId;
   setRenewalRecord(renewalData);
-  const mergedFormData = await buildFormDataFromRenewalRecord(renewalData, applicationId);
+  const mergedFormData = await buildFormDataFromRenewalRecord(renewalData, licenseId);
   const { formData: syncedForm, synced } = await applyPrefilledDocumentUploads(
     existingRenewalId,
     mergedFormData
@@ -2066,13 +2042,13 @@ const loadExistingRenewalByLicenseNumber = async (
       : `Loaded existing renewal application ${getTextValue(renewalData?.acknowledgementNo, existingRenewalId)} for license ${licenseNumber}.`
   );
   router.replace(
-    `/forms/renewal?licenseId=${encodeURIComponent(applicationId)}&renewalId=${encodeURIComponent(existingRenewalId)}`
+    `/forms/renewal?licenseId=${encodeURIComponent(licenseId)}&renewalId=${encodeURIComponent(existingRenewalId)}`
   );
   return true;
 };
 
 const createDraftRenewalFromFreshApplication = async (
-  applicationId: string,
+  licenseId: string,
   prefilledForm: RenewalFormState,
   setRenewalRecord: React.Dispatch<React.SetStateAction<any>>,
   setFormData: React.Dispatch<React.SetStateAction<RenewalFormState>>,
@@ -2083,18 +2059,8 @@ const createDraftRenewalFromFreshApplication = async (
   if (createdRenewalIdRef.current) return;
 
   const licenseNumber = prefilledForm.licenseNumber.trim();
-  if (licenseNumber) {
-    const loadedExisting = await loadExistingRenewalByLicenseNumber(
-      applicationId,
-      licenseNumber,
-      setRenewalRecord,
-      setFormData,
-      setStatusMessage,
-      router,
-      createdRenewalIdRef
-    );
-    if (loadedExisting) return;
-  }
+
+
 
   setFormData(prefilledForm);
 
@@ -2121,7 +2087,7 @@ const createDraftRenewalFromFreshApplication = async (
         : `Created renewal application ${getTextValue(created?.acknowledgementNo, newRenewalId)}.`
     );
     router.replace(
-      `/forms/renewal?licenseId=${encodeURIComponent(applicationId)}&renewalId=${encodeURIComponent(newRenewalId)}`
+      `/forms/renewal?licenseId=${encodeURIComponent(licenseId)}&renewalId=${encodeURIComponent(newRenewalId)}`
     );
   } catch (createError: any) {
     const message = String(createError?.message || '');
@@ -2131,7 +2097,7 @@ const createDraftRenewalFromFreshApplication = async (
 
     if (renewalAlreadyExists && licenseNumber) {
       const loadedExisting = await loadExistingRenewalByLicenseNumber(
-        applicationId,
+        licenseId,
         licenseNumber,
         setRenewalRecord,
         setFormData,
@@ -2152,7 +2118,6 @@ function RenewalFormPageContent() {
   const licenseId = searchParams?.get('licenseId') || '';
   const urlLicenseId =
     licenseId ||
-    searchParams?.get('applicationId') ||
     searchParams?.get('freshApplicationId') || '';
   const renewalId = searchParams?.get('renewalId') || searchParams?.get('id') || '';
   const createdRenewalIdRef = useRef<string | null>(null);
@@ -2167,6 +2132,7 @@ function RenewalFormPageContent() {
   // Tracks whether the user has actively edited the form, so auto-navigation
   // between sections only triggers after real interaction (not on initial load).
   const hasUserInteractedRef = React.useRef(false);
+  const hasInitializedRef = React.useRef(false);
   // Tracks the previous per-section validity so we can detect when a section
   // newly becomes complete and auto-scroll to the next incomplete section.
   const sectionValidityRef = React.useRef<Record<string, boolean> | null>(null);
@@ -2185,8 +2151,8 @@ function RenewalFormPageContent() {
   const [isVerified, setIsVerified] = useState(false);
   const [verificationChecking, setVerificationChecking] = useState(false);
   const [verificationStatus, setVerificationStatus] = useState<
-    'ENTER_APP_ID' | 'VERIFYING_BIOMETRICS' | 'VERIFIED' | 'FAILED'
-  >('ENTER_APP_ID');
+    'ENTER_LICENSE_ID' | 'VERIFYING_BIOMETRICS' | 'VERIFIED' | 'FAILED'
+  >('ENTER_LICENSE_ID');
   const [verificationError, setVerificationError] = useState<string | null>(null);
   const [biometricTargetThumb, setBiometricTargetThumb] = useState<string | null>(null);
   const [applicantDetails, setApplicantDetails] = useState<{
@@ -2362,7 +2328,7 @@ function RenewalFormPageContent() {
         .map((f: any) => ({
           template: f.template,
           fingerPosition: f.position,
-          applicationId: numericLicenseId,
+          licenseId: numericLicenseId,
         }));
 
       const name =
@@ -2391,7 +2357,7 @@ function RenewalFormPageContent() {
       }
     } catch (err: any) {
       setVerificationError(err?.message || 'Failed to fetch license details.');
-      setVerificationStatus('ENTER_APP_ID');
+      setVerificationStatus('ENTER_LICENSE_ID');
     } finally {
       setVerificationChecking(false);
     }
@@ -2417,7 +2383,7 @@ function RenewalFormPageContent() {
         renewalData?.licenseId,
         renewalData?.freshLicenseId,
         renewalData?.licenseNumber,
-        renewalData?.applicationId,
+        renewalData?.licenseId,
         renewalData?.freshApplicationId,
         renewalData?.sourceApplicationId
       );
@@ -2428,19 +2394,19 @@ function RenewalFormPageContent() {
       await checkBiometricRequirement(resolvedLicense);
     } catch (err: any) {
       setVerificationError(err?.message || 'Failed to resolve license details.');
-      setVerificationStatus('ENTER_APP_ID');
+      setVerificationStatus('ENTER_LICENSE_ID');
       setVerificationChecking(false);
     }
   };
 
-  const resolveLicenseId = async (lid: string) => {
+  const handleLicenseVerification = async (lid: string) => {
     try {
       setVerificationChecking(true);
       setVerificationError(null);
       await checkBiometricRequirement(lid);
     } catch (err: any) {
       setVerificationError(err?.message || 'Failed to resolve license details.');
-      setVerificationStatus('ENTER_APP_ID');
+      setVerificationStatus('ENTER_LICENSE_ID');
     } finally {
       setVerificationChecking(false);
     }
@@ -2582,9 +2548,9 @@ function RenewalFormPageContent() {
       resolveRenewalLicenseAndCheck(renewalId);
     } else if (urlLicenseId) {
       setEnteredLicenseId(urlLicenseId);
-      resolveLicenseId(urlLicenseId);
+      handleLicenseVerification(urlLicenseId);
     } else {
-      setVerificationStatus('ENTER_APP_ID');
+      setVerificationStatus('ENTER_LICENSE_ID');
       setIsLoading(false);
     }
   }, [urlLicenseId, renewalId]);
@@ -2731,22 +2697,8 @@ function RenewalFormPageContent() {
 
       setRenewalRecord(renewalData);
 
-      // Fetch fresh application data to display and pre-fill renewal form
-      const freshData = await fetchFreshApplicationWithFiles(resolvedLicenseId);
-      let mergedFormData: RenewalFormState;
-      if (freshData) {
-        const freshFormState = buildFieldStateFromFreshApplication(
-          resolvedLicenseId,
-          freshData
-        );
-        const renewalFormData = await buildFormDataFromRenewalRecord(
-          renewalData,
-          resolvedLicenseId
-        );
-        mergedFormData = mergeRenewalStateOverFresh(freshFormState, renewalFormData, renewalData);
-      } else {
-        mergedFormData = await buildFormDataFromRenewalRecord(renewalData, resolvedLicenseId);
-      }
+      // Do NOT fetch fresh data if we already have the renewal record.
+      const mergedFormData = await buildFormDataFromRenewalRecord(renewalData, resolvedLicenseId);
 
       const { formData: syncedForm, synced } = await applyPrefilledDocumentUploads(
         rId,
@@ -2762,6 +2714,9 @@ function RenewalFormPageContent() {
     };
 
     const load = async () => {
+      if (hasInitializedRef.current) return;
+      hasInitializedRef.current = true;
+      
       try {
         setIsLoading(true);
         setError(null);
@@ -2774,11 +2729,12 @@ function RenewalFormPageContent() {
         }
 
         // Path B: Only licenseId — fetch license, check for existing renewal.
-        // Step 1: Fetch fresh application data to extract licenseNumber.
-        const freshData = await fetchFreshApplicationWithFiles(resolvedLicenseId);
+        // Step 1: Fetch license data exactly ONCE.
+        const applicationCheckResponse = await ApplicationService.getLicense(resolvedLicenseId);
+        const freshData = extractData(applicationCheckResponse);
 
         if (!freshData) {
-          throw new Error('No fresh application data found for the provided ID.');
+          throw new Error('No license data found for the provided ID.');
         }
 
         const licenseNumber = getLicenseNumber(freshData);
@@ -2805,17 +2761,15 @@ function RenewalFormPageContent() {
           }
         }
 
-        const prefilledForm = buildFieldStateFromFreshApplication(resolvedLicenseId, freshData);
-
-        // Validate that the fresh application has been submitted.
-        const applicationCheckResponse =
-          await ApplicationService.getLicense(resolvedLicenseId);
+        // Validate that the license has been submitted/approved.
         const isSubmitted =
           applicationCheckResponse?.isSubmit === true ||
-          applicationCheckResponse?.data?.isSubmit === true;
+          freshData?.isSubmit === true;
         if (!isSubmitted) {
           throw new Error('Your application has not been submitted.');
         }
+
+        const prefilledForm = buildFieldStateFromFreshApplication(resolvedLicenseId, freshData);
 
         await createDraftRenewalFromFreshApplication(
           resolvedLicenseId,
@@ -2828,6 +2782,7 @@ function RenewalFormPageContent() {
         );
       } catch (loadError: any) {
         setError(loadError?.message || 'Failed to load the renewal form.');
+        hasInitializedRef.current = false; // allow retry on error
       } finally {
         setIsLoading(false);
       }
@@ -3471,6 +3426,16 @@ function RenewalFormPageContent() {
       toast.success(
         `${sectionKey.charAt(0).toUpperCase() + sectionKey.slice(1)} section saved successfully.`
       );
+
+      // Auto-navigate to the next incomplete section
+      const startIdx = SECTION_FLOW_ORDER.indexOf(sectionKey as typeof SECTION_FLOW_ORDER[number]);
+      const nextIncomplete = SECTION_FLOW_ORDER.slice(startIdx + 1).find(
+        key => !sectionCompleted[key]
+      );
+      const target = nextIncomplete ?? 'declaration';
+
+      setExpandedSections(prev => ({ ...prev, [target]: true }));
+      scrollToSectionTop(target);
     } catch (err: any) {
       toast.error(err?.message || 'Failed to save section. Please try again.');
       setSectionCompleted(prev => ({ ...prev, [sectionKey]: false }));
@@ -3479,38 +3444,6 @@ function RenewalFormPageContent() {
       setSavingSection(null);
     }
   };
-
-  useEffect(() => {
-    // Keep the section progress indicator in sync with field validity in real time,
-    // and auto-navigate to the next incomplete section as each one is completed.
-    if (isLoading) return;
-
-    const validity = computeSectionValidity(formData);
-
-    setSectionCompleted(prev => {
-      const changed = SECTION_FLOW_ORDER.some(key => prev[key] !== validity[key]);
-      return changed ? { ...prev, ...validity } : prev;
-    });
-
-    const prevValidity = sectionValidityRef.current;
-    sectionValidityRef.current = validity;
-
-    // Skip the very first computation and any change not driven by the user so the
-    // form does not jump around on initial load / prefill.
-    if (!prevValidity || !hasUserInteractedRef.current) return;
-
-    const newlyCompleted = SECTION_FLOW_ORDER.find(
-      key => validity[key] && !prevValidity[key]
-    );
-    if (!newlyCompleted) return;
-
-    const startIdx = SECTION_FLOW_ORDER.indexOf(newlyCompleted);
-    const nextIncomplete = SECTION_FLOW_ORDER.slice(startIdx + 1).find(key => !validity[key]);
-    const target = nextIncomplete ?? 'declaration';
-
-    setExpandedSections(prev => ({ ...prev, [target]: true }));
-    scrollToSectionTop(target);
-  }, [formData, isLoading]);
 
   const persistRenewalForm = async (isSubmit: boolean) => {
     const activeRenewalId = renewalId || createdRenewalIdRef.current;
@@ -3596,7 +3529,7 @@ function RenewalFormPageContent() {
       if (saved) {
         const mergedFormData = await buildFormDataFromRenewalRecord(
           saved,
-          resolveFreshApplicationId(saved, resolvedLicenseId)
+          resolveLicenseId(saved, resolvedLicenseId)
         );
         const { formData: syncedForm } = await applyPrefilledDocumentUploads(
           activeRenewalId,
@@ -3759,7 +3692,7 @@ function RenewalFormPageContent() {
       setRenewalRecord(renewalData);
       const merged = await buildFormDataFromRenewalRecord(
         renewalData,
-        resolveFreshApplicationId(renewalData, resolvedLicenseId)
+        resolveLicenseId(renewalData, resolvedLicenseId)
       );
       const { formData: syncedForm } = await applyPrefilledDocumentUploads(activeRenewalId, merged);
       setFormData(syncedForm as RenewalFormState);
@@ -3785,7 +3718,7 @@ function RenewalFormPageContent() {
         />
         <div className='relative flex-grow flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 z-10'>
           <div className='max-w-md w-full space-y-6 bg-white/90 p-10 rounded-lg shadow-xl backdrop-blur-sm border border-white/40 transition-all duration-300'>
-            {verificationChecking && verificationStatus === 'ENTER_APP_ID' ? (
+            {verificationChecking && verificationStatus === 'ENTER_LICENSE_ID' ? (
               <div className='space-y-6 py-8 text-center'>
                 <div className='mx-auto w-12 h-12 border-4 border-[#001F54] border-t-transparent rounded-full animate-spin flex items-center justify-center'>
                   <span className='text-xl'>🪪</span>
@@ -3794,7 +3727,7 @@ function RenewalFormPageContent() {
                 <p className='text-sm text-gray-500'>Checking biometric requirements</p>
               </div>
             ) : (
-              verificationStatus === 'ENTER_APP_ID' && (
+              verificationStatus === 'ENTER_LICENSE_ID' && (
                 <div className='space-y-6'>
                   <div className='text-center'>
                     <div className='mb-6 flex justify-center'>
@@ -4045,7 +3978,7 @@ function RenewalFormPageContent() {
                 <div className='space-y-3'>
                   <button
                     onClick={() => {
-                      setVerificationStatus('ENTER_APP_ID');
+                      setVerificationStatus('ENTER_LICENSE_ID');
                       setVerificationError(null);
                     }}
                     className='w-full flex justify-center py-2.5 px-4 border border-gray-300 rounded-md text-sm font-semibold text-gray-700 bg-white hover:bg-gray-50 transition-colors shadow-sm'

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -63,7 +63,7 @@ const Header = (props: HeaderProps) => {
   const [showNotifications, setShowNotifications] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
-  const [cancelApplicationId, setCancelApplicationId] = useState('');
+  const [cancelLicenseId, setCancelLicenseId] = useState('');
   const [cancelLookupError, setCancelLookupError] = useState<string | null>(null);
   const [isCancelLookupLoading, setIsCancelLookupLoading] = useState(false);
 
@@ -87,7 +87,7 @@ const Header = (props: HeaderProps) => {
       } else if (type.key === 'renewal') {
         router.push('/forms/renewal');
       } else if (type.key === 'cancel') {
-        setCancelApplicationId('');
+        setCancelLicenseId('');
         setCancelLookupError(null);
         setShowCancelModal(true);
       } else {
@@ -99,10 +99,10 @@ const Header = (props: HeaderProps) => {
   };
 
   const handleCancelSubmit = async () => {
-    const id = cancelApplicationId.trim();
+    const id = cancelLicenseId.trim();
 
     if (!id) {
-      setCancelLookupError('Enter a Fresh Application ID or Acknowledgement Number.');
+      setCancelLookupError('Enter a License ID or License Number.');
       return;
     }
 
@@ -110,11 +110,11 @@ const Header = (props: HeaderProps) => {
       setIsCancelLookupLoading(true);
       setCancelLookupError(null);
 
-      const response = await ApplicationService.getApplication(id);
+      const response = await ApplicationService.getLicense(id);
       const freshApplication = response?.data ?? response;
 
       if (!freshApplication) {
-        throw new Error('No fresh application data returned for that ID.');
+        throw new Error('No license data returned for that ID or number.');
       }
 
       const workflowStatusCode = freshApplication?.workflowStatus?.code?.toString().toUpperCase();
@@ -125,15 +125,16 @@ const Header = (props: HeaderProps) => {
         );
 
       if (workflowStatusCode !== 'APPROVED' && !hasApprovedHistory) {
-        throw new Error('Only approved fresh applications can create a cancellation form.');
+        throw new Error('Only approved licenses can create a cancellation form.');
       }
 
-      // Check if a cancellation request already exists for this application
+      // Check if a cancellation request already exists for this license
       try {
-        const existingCancelResponse = await CancelService.getCancelRequests({ freshLicenseId: Number(freshApplication.id) });
+        const resolvedLicenseId = Number(freshApplication.licenseId || freshApplication.id);
+        const existingCancelResponse = await CancelService.getCancelRequests({ licenseId: resolvedLicenseId });
         const existingCancel = existingCancelResponse?.data || existingCancelResponse;
         if (Array.isArray(existingCancel) && existingCancel.length > 0) {
-          throw new Error('A cancellation request already exists for this application.');
+          throw new Error('A cancellation request already exists for this license.');
         }
       } catch (err: any) {
         if (!err.message.includes('already exists')) {
@@ -145,7 +146,7 @@ const Header = (props: HeaderProps) => {
 
       setShowCancelModal(false);
       router.push(
-        `/cancelForm/new?applicationId=${encodeURIComponent(String(freshApplication.id))}`
+        `/cancelForm/new?licenseId=${encodeURIComponent(String(freshApplication.licenseId || freshApplication.id))}`
       );
     } catch (error: any) {
       const message = error?.message || 'Unable to fetch fresh application data.';
@@ -424,24 +425,24 @@ const Header = (props: HeaderProps) => {
           <div className='w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl'>
             <h2 className='text-lg font-semibold text-gray-900'>Cancel Application</h2>
             <p className='mt-2 text-sm text-gray-600'>
-              Enter the approved Fresh Application ID or Acknowledgement Number to initiate the cancellation request.
+              Enter the approved License ID or License Number to initiate the cancellation request.
             </p>
 
             <div className='mt-4'>
               <label
-                htmlFor='cancel-application-id'
+                htmlFor='cancel-license-id'
                 className='block text-sm font-medium text-gray-700'
               >
-                Fresh Application ID / Acknowledgement Number
+                License ID / License Number
               </label>
               <input
-                id='cancel-application-id'
-                value={cancelApplicationId}
+                id='cancel-license-id'
+                value={cancelLicenseId}
                 onChange={e => {
-                  setCancelApplicationId(e.target.value);
+                  setCancelLicenseId(e.target.value);
                   if (cancelLookupError) setCancelLookupError(null);
                 }}
-                placeholder='Enter ID or Acknowledgement Number (e.g., ALMS...)'
+                placeholder='Enter License ID or License Number (e.g., LUAN...)'
                 className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-[#001F54] focus:ring-2 focus:ring-[#001F54]/20'
                 autoFocus
               />

--- a/frontend/src/components/cancelForm/CancelRequestDetail.tsx
+++ b/frontend/src/components/cancelForm/CancelRequestDetail.tsx
@@ -1,20 +1,16 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   StatusBadge,
   DetailItem,
   SectionCard,
-  DocumentTable,
 } from '@/app/application/components/RedesignedComponents';
+import EnhancedApplicationTimeline from '@/components/EnhancedApplicationTimeline';
 import {
   UserRound,
-  UserCheck,
   CalendarDays,
-  CreditCard,
   Fingerprint,
-  FileCheck,
-  UserCog,
   BadgeCheck,
   Clock3,
   Shield,
@@ -26,495 +22,445 @@ import {
   Package,
   FileText,
   History,
-  Users,
-  BriefcaseBusiness,
+  ClipboardCheck,
+  Building2,
+  ShieldAlert,
   AlertTriangle,
-  FileSearch,
+  Users,
+  TriangleAlert,
+  FileWarning,
+  Ban,
   Scale,
+  BriefcaseBusiness,
+  Loader2,
+  FileQuestion,
+  Info,
+  Building
 } from 'lucide-react';
-import { formatGender } from '@/utils/formatters';
+import { ApplicationService } from '@/api/applicationService';
 import RenewalApplicationDetailsHeader from '@/components/renewal/renewalapplicationdetailsheader';
+import { getStatusStyle } from '@/utils/statusColors';
+import { RichTextDisplay } from '@/components/RichTextDisplay';
+
+const fmtDate = (value?: string) => {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString('en-IN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+const yn = (value?: boolean) => (value ? 'YES' : 'NO');
+
+const hexToRgba = (hex: string, alpha: number): string => {
+  const cleanHex = hex.replace('#', '');
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
 
 interface CancelRequestDetailProps {
   request: any;
-  freshApplication?: any;
+  licenseId?: number | string | null;
+  licenseNumber?: string | null;
   activeTab: 'info' | 'original';
   onTabChange: (tab: string) => void;
+  loading?: boolean;
+  // When true, the Original License Details tab has been opened and the
+  // License GET API should be (lazily) fetched once using the cancel response's licenseId.
+  loadOriginal?: boolean;
 }
 
-export function CancelTimeline({ histories }: { histories: any[] }) {
-  if (!histories || histories.length === 0) {
+export default function CancelRequestDetail({
+  request,
+  licenseId,
+  licenseNumber,
+  activeTab,
+  onTabChange,
+  loading,
+  loadOriginal,
+}: CancelRequestDetailProps) {
+  const [licenseData, setLicenseData] = useState<any>(null);
+  const [licenseLoading, setLicenseLoading] = useState(false);
+  const [licenseError, setLicenseError] = useState<string | null>(null);
+
+  // Lazily fetch the License GET API (GET /api/licenses/:licenseId) ONLY when:
+  //  - the Original License Details tab is opened (loadOriginal), and
+  //  - we have a licenseId from the Cancellation GET API response, and
+  //  - it has not already been fetched (prevents duplicate calls on re-renders).
+  // No Fresh Application API is used here.
+  const licenseFetchedFor = React.useRef<string | null>(null);
+  useEffect(() => {
+    if (!loadOriginal) return;
+    const identifier = licenseId || licenseNumber;
+    if (!identifier) return;
+    if (licenseFetchedFor.current === String(identifier)) return;
+
+    let cancelled = false;
+    licenseFetchedFor.current = String(identifier);
+    const loadLicense = async () => {
+      try {
+        setLicenseLoading(true);
+        setLicenseError(null);
+        const res = await ApplicationService.getLicense(String(identifier));
+        const data = res?.data ?? res;
+        if (!cancelled) setLicenseData(data || null);
+      } catch (err: any) {
+        if (!cancelled) setLicenseError(err?.message || 'Failed to load license details.');
+      } finally {
+        if (!cancelled) setLicenseLoading(false);
+      }
+    };
+
+    loadLicense();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadOriginal, licenseId, licenseNumber]);
+
+  if (!request) return null;
+
+  // Applicant name comes from the Licenses object in the Cancellation GET API response.
+  const license = request.Licenses || {};
+  const applicantName = [license.firstName, license.middleName, license.lastName]
+    .filter(Boolean)
+    .join(' ') || request.applicantName || 'N/A';
+
+  if (licenseLoading) {
     return (
-      <div className='flex flex-col items-center justify-center py-10 text-center text-slate-500 bg-slate-50 rounded-xl border border-slate-100 w-full'>
-        <History className='w-8 h-8 text-slate-300 mb-2' />
-        <p className='text-sm font-semibold text-slate-700'>No history entries yet</p>
-        <p className='text-xs text-slate-400 mt-1'>
-          Actions taken on this request will appear here.
-        </p>
+      <div className='rounded-3xl bg-white shadow-xl border border-slate-200 flex items-center justify-center gap-3 py-20 text-slate-500'>
+        <Loader2 className='w-5 h-5 animate-spin' />
+        <span className='text-sm font-medium'>Loading license details…</span>
+      </div>
+    );
+  }
+
+  if (licenseError) {
+    return (
+      <div className='rounded-3xl bg-red-50 border border-red-200 shadow-sm p-8 text-center text-sm font-medium text-red-700'>
+        {licenseError}
       </div>
     );
   }
 
   return (
-    <div className='relative border-l-2 border-red-200 ml-4 pl-6 space-y-6 w-full'>
-      {histories.map((entry: any, index: number) => {
-        const formattedDate = entry.createdAt
-          ? new Date(entry.createdAt).toLocaleString('en-IN', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })
-          : '';
-
-        return (
-          <div key={entry.id || index} className='relative'>
-            {/* Timeline node icon */}
-            <span className='absolute -left-[35px] top-1 flex h-6 w-6 items-center justify-center rounded-full bg-red-50 text-red-600 ring-4 ring-white border border-red-200 shadow-sm'>
-              <UserCog className='h-3 w-3' />
-            </span>
-            <div className='bg-white border border-slate-200 rounded-xl p-4 hover:shadow-md transition-all duration-300'>
-              <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 mb-2'>
-                <span className='font-bold text-slate-800 text-sm'>
-                  {entry.previousUser?.username || 'Initiator'}
-                  {entry.previousRole?.name && (
-                    <span className='text-xs text-slate-500 font-medium ml-1'>
-                      ({entry.previousRole.name})
-                    </span>
-                  )}
-                </span>
-                <span className='text-[10px] text-slate-400 font-bold tracking-wider uppercase'>
-                  {formattedDate}
-                </span>
-              </div>
-              <div className='mb-2'>
-                <span className='inline-flex items-center px-2 py-0.5 rounded text-[10px] font-extrabold tracking-wider bg-red-50 text-red-700 border border-red-100 uppercase'>
-                  Action: {entry.actionTaken}
-                </span>
-              </div>
-              {entry.remarks && (
-                <p className='text-slate-600 text-xs mt-1.5 p-2 bg-slate-50 border border-slate-100 rounded-lg whitespace-pre-line leading-relaxed'>
-                  {entry.remarks}
-                </p>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-export default function CancelRequestDetail({
-  request,
-  freshApplication,
-  activeTab,
-  onTabChange,
-}: CancelRequestDetailProps) {
-  if (!request) return null;
-
-  const freshApp = freshApplication || request.freshLicense;
-  const applicantName = freshApp
-    ? [freshApp.firstName, freshApp.middleName, freshApp.lastName].filter(Boolean).join(' ')
-    : 'N/A';
-
-  const requestView = (
-    <div className='rounded-3xl bg-white shadow-xl overflow-hidden'>
-      <div className='grid gap-6 p-6 md:grid-cols-[1.4fr_1fr]'>
-        <div className='space-y-4'>
-          <div className='rounded-2xl bg-slate-50 p-5'>
-            <div className='flex items-center justify-between'>
-              <h2 className='text-sm font-semibold uppercase tracking-[0.18em] text-slate-500'>
-                Request Details
-              </h2>
-            </div>
-            <div className='mt-5 space-y-4'>
-              <InfoCard
-                label='Reason for Cancellation'
-                value={request.cancellationReason || 'N/A'}
-              />
-              {request.remarks && (
-                <div className='rounded-2xl bg-white p-4'>
-                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2'>
-                    Additional Remarks / Process History
-                  </p>
-                  <p className='text-sm leading-relaxed text-slate-700 whitespace-pre-line'>
-                    {request.remarks}
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className='space-y-4'>
-          <div className='rounded-2xl bg-slate-50 p-5'>
-            <div className='flex items-center justify-between'>
-              <h2 className='text-sm font-semibold uppercase tracking-[0.18em] text-slate-500'>
-                Timeline & Metadata
-              </h2>
-            </div>
-            <div className='mt-5 grid gap-4'>
-              <InfoCard label='Requested By' value={request.requester?.username || 'Unknown'} />
-              <InfoCard label='User Role' value={request.requester?.role?.name || 'N/A'} />
-              <InfoCard
-                label='Requested Date'
-                value={
-                  request.requestedDate
-                    ? new Date(request.requestedDate).toLocaleDateString()
-                    : new Date(request.createdAt).toLocaleDateString()
-                }
-              />
-              {request.status !== 'PENDING' && (request.actionedDate || request.updatedAt) && (
-                <InfoCard
-                  label='Actioned Date'
-                  value={new Date(request.actionedDate || request.updatedAt).toLocaleDateString()}
-                />
-              )}
-              {request.actioner && (
-                <InfoCard label='Actioned By' value={request.actioner.username} />
-              )}
-              {request.workflowStatus && (
-                <InfoCard label='Current Stage' value={request.workflowStatus.name} />
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  const originalView = (
-    <div className='space-y-6'>
-      <div className='bg-white rounded-xl border border-slate-200 p-6 shadow-sm'>
-        <h3 className='text-sm font-bold text-gray-800 uppercase tracking-wider mb-4 border-b border-slate-100 pb-2 flex items-center gap-2'>
-          <UserRound className='w-4 h-4 text-red-600' />
-          Applicant Personal Info
-        </h3>
-        <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-          <DetailItem label='Full Name' value={applicantName} icon={UserRound} />
-          <DetailItem label='Parent/Spouse Name' value={freshApp.parentOrSpouseName} icon={Users} />
-          <DetailItem label='Gender' value={formatGender(freshApp.sex)} icon={UserCheck} />
-
-          {freshApp.dateOfBirth && (
-            <DetailItem
-              label='Date of Birth'
-              value={new Date(freshApp.dateOfBirth).toLocaleDateString('en-IN', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-              icon={CalendarDays}
-            />
-          )}
-          <DetailItem label='Place of Birth' value={freshApp.placeOfBirth} icon={MapPin} />
-          <DetailItem label='Aadhar Number' value={freshApp.aadharNumber} icon={Fingerprint} mono />
-          <DetailItem label='PAN Number' value={freshApp.panNumber} icon={CreditCard} mono />
-          <DetailItem
-            label='Acknowledgement No'
-            value={freshApp.acknowledgementNo}
-            icon={FileCheck}
-            mono
-          />
-          <DetailItem
-            label='Workflow Status'
-            value={<StatusBadge status={freshApp.workflowStatus} />}
-            icon={BadgeCheck}
-          />
-        </div>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-        {freshApp.presentAddress && (
-          <SectionCard
-            title='Present Address'
-            icon={MapPin}
-            iconColorClass='text-purple-600 bg-purple-50 border-purple-100'
-          >
-            <div className='space-y-3'>
-              <p className='text-slate-800 font-medium text-sm bg-slate-50 p-3 rounded-lg border border-slate-100'>
-                {freshApp.presentAddress.addressLine}
-              </p>
-              <div className='grid grid-cols-2 gap-2 text-xs'>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    District
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.presentAddress.district?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>State</span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.presentAddress.state?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    Police Station
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.presentAddress.policeStation?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    Division
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.presentAddress.division?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>Zone</span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.presentAddress.zone?.name || 'N/A'}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </SectionCard>
-        )}
-
-        {freshApp.permanentAddress && (
-          <SectionCard
-            title='Permanent Address'
-            icon={MapPin}
-            iconColorClass='text-indigo-600 bg-indigo-50 border-indigo-100'
-          >
-            <div className='space-y-3'>
-              <p className='text-slate-800 font-medium text-sm bg-slate-50 p-3 rounded-lg border border-slate-100'>
-                {freshApp.permanentAddress.addressLine}
-              </p>
-              <div className='grid grid-cols-2 gap-2 text-xs'>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    District
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.permanentAddress.district?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>State</span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.permanentAddress.state?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    Police Station
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.permanentAddress.policeStation?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>
-                    Division
-                  </span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.permanentAddress.division?.name || 'N/A'}
-                  </span>
-                </div>
-                <div>
-                  <span className='text-slate-400 font-bold uppercase block text-[9px]'>Zone</span>
-                  <span className='font-semibold text-slate-700'>
-                    {freshApp.permanentAddress.zone?.name || 'N/A'}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </SectionCard>
-        )}
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-        {freshApp.licenseDetails?.[0] && (
-          <SectionCard
-            title='License Specifications'
-            icon={Shield}
-            iconColorClass='text-blue-600 bg-blue-50 border-blue-100'
-          >
-            <div className='space-y-3'>
-              <DetailItem
-                label='Need for License'
-                value={freshApp.licenseDetails[0].needForLicense}
-                icon={Target}
-              />
-              <DetailItem
-                label='Category of Arms'
-                value={freshApp.licenseDetails[0].armsCategory}
-                icon={ShieldCheck}
-              />
-              <DetailItem
-                label='Area of Validity'
-                value={freshApp.licenseDetails[0].areaOfValidity}
-                icon={MapPin}
-              />
-              <DetailItem
-                label='Ammunition Specification'
-                value={freshApp.licenseDetails[0].ammunitionDescription}
-                icon={Package}
-              />
-              <DetailItem
-                label='Special Consideration'
-                value={freshApp.licenseDetails[0].specialConsiderationReason}
-                icon={FileText}
-              />
-            </div>
-          </SectionCard>
-        )}
-
-        {freshApp.occupationAndBusiness && (
-          <SectionCard
-            title='Occupation & Business'
-            icon={BriefcaseBusiness}
-            iconColorClass='text-teal-600 bg-teal-50 border-teal-100'
-          >
-            <div className='space-y-3'>
-              <DetailItem
-                label='Occupation'
-                value={freshApp.occupationAndBusiness.occupation}
-                icon={BriefcaseBusiness}
-              />
-              <DetailItem
-                label='Office Address'
-                value={freshApp.occupationAndBusiness.officeAddress}
-                icon={MapPin}
-              />
-              <DetailItem
-                label='Crop Location'
-                value={freshApp.occupationAndBusiness.cropLocation}
-                icon={LocateFixed}
-              />
-              {freshApp.occupationAndBusiness.areaUnderCultivation && (
-                <DetailItem
-                  label='Area Under Cultivation'
-                  value={`${freshApp.occupationAndBusiness.areaUnderCultivation} Acres`}
-                  icon={FileText}
-                />
-              )}
-            </div>
-          </SectionCard>
-        )}
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-        {freshApp.criminalHistories?.[0] && (
-          <SectionCard
-            title='Criminal Verification'
-            icon={AlertTriangle}
-            iconColorClass='text-red-600 bg-red-50 border-red-100'
-          >
-            <div className='space-y-3'>
-              <div className='flex justify-between items-center text-sm font-semibold text-slate-700 bg-slate-50 p-2.5 rounded-lg border border-slate-100'>
-                <span>Convicted in Court:</span>
-                <span
-                  className={
-                    freshApp.criminalHistories[0].isConvicted ? 'text-red-600' : 'text-green-600'
-                  }
-                >
-                  {freshApp.criminalHistories[0].isConvicted ? 'YES' : 'NO'}
-                </span>
-              </div>
-              <div className='flex justify-between items-center text-sm font-semibold text-slate-700 bg-slate-50 p-2.5 rounded-lg border border-slate-100'>
-                <span>Bond Executed:</span>
-                <span
-                  className={
-                    freshApp.criminalHistories[0].isBondExecuted ? 'text-red-600' : 'text-green-600'
-                  }
-                >
-                  {freshApp.criminalHistories[0].isBondExecuted ? 'YES' : 'NO'}
-                </span>
-              </div>
-              <div className='flex justify-between items-center text-sm font-semibold text-slate-700 bg-slate-50 p-2.5 rounded-lg border border-slate-100'>
-                <span>Prohibited:</span>
-                <span
-                  className={
-                    freshApp.criminalHistories[0].isProhibited ? 'text-red-600' : 'text-green-600'
-                  }
-                >
-                  {freshApp.criminalHistories[0].isProhibited ? 'YES' : 'NO'}
-                </span>
-              </div>
-            </div>
-          </SectionCard>
-        )}
-
-        {freshApp.licenseHistories?.[0] && (
-          <SectionCard
-            title='Previous License History'
-            icon={History}
-            iconColorClass='text-amber-600 bg-amber-50 border-amber-100'
-          >
-            <div className='space-y-3'>
-              <DetailItem
-                label='Has Applied Before'
-                value={freshApp.licenseHistories[0].hasAppliedBefore ? 'YES' : 'NO'}
-                icon={FileSearch}
-              />
-              {freshApp.licenseHistories[0].hasAppliedBefore && (
-                <>
-                  <DetailItem
-                    label='Previous Authority'
-                    value={freshApp.licenseHistories[0].previousAuthorityName}
-                    icon={FileText}
-                  />
-                  <DetailItem
-                    label='Previous Result'
-                    value={freshApp.licenseHistories[0].previousResult}
-                    icon={Scale}
-                  />
-                </>
-              )}
-              <DetailItem
-                label='License Suspended / Revoked'
-                value={freshApp.licenseHistories[0].hasLicenceSuspended ? 'YES' : 'NO'}
-                icon={AlertTriangle}
-              />
-            </div>
-          </SectionCard>
-        )}
-      </div>
-
-      {freshApp.fileUploads && (
-        <div className='bg-white rounded-xl border border-slate-200 p-6 shadow-sm'>
-          <h3 className='text-sm font-bold text-gray-800 uppercase tracking-wider mb-4 border-b border-slate-100 pb-2 flex items-center gap-2'>
-            <FileText className='w-4 h-4 text-red-600' />
-            Uploaded Documents
-          </h3>
-          <DocumentTable documents={freshApp.fileUploads} />
-        </div>
-      )}
-    </div>
-  );
-
-  return (
-    <div className='space-y-6'>
+    <div data-printable='application-card' className='space-y-6'>
       <RenewalApplicationDetailsHeader
         applicationId={request.id}
-        acknowledgementNo={request.acknowledgementNo || freshApp?.acknowledgementNo}
-        activeTab={activeTab === 'info' ? 'Cancellation Info' : 'Original Application Details'}
-        tabs={
-          freshApp ? ['Cancellation Info', 'Original Application Details'] : ['Cancellation Info']
-        }
+        licenseId={request.licenseId}
+        acknowledgementNo={request.acknowledgementNo}
+        imageSrc='/file.svg'
+        activeTab={activeTab === 'original' ? 'License Details' : 'Cancellation Info'}
+        tabs={["Cancellation Info", "License Details"]}
         onTabChange={onTabChange}
         accentColorClass='bg-gradient-to-b from-red-500 to-red-400'
         smallLabel='CANCELLATION REQUEST'
         title='Cancellation Request'
       />
 
-      {activeTab === 'info' ? requestView : originalView}
+        {/* Cancellation Info tab: only data from the Cancellation GET API response. */}
+        {activeTab === 'info' && (
+          <>
+            {loading && (
+              <div className='rounded-3xl bg-white shadow-xl border border-slate-200 flex items-center justify-center gap-3 py-20 text-slate-500'>
+                <Loader2 className='w-5 h-5 animate-spin' />
+                <span className='text-sm font-medium'>Loading cancellation info…</span>
+              </div>
+            )}
+
+            {!loading && (
+              <>
+                {/* Key identifiers from the Cancellation API */}
+                <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+                  <div className='grid gap-6 p-6 md:grid-cols-3'>
+                    <DetailItem label='Acknowledgement Number' value={request.acknowledgementNo} icon={FileText} mono />
+                    <DetailItem label='License ID' value={request.licenseId} icon={Fingerprint} mono />
+                    <DetailItem label='License Number' value={license.licenseNumber || request.licenseNumber} icon={ShieldCheck} mono />
+                  </div>
+                </div>
+
+                <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 items-start'>
+                  {/* Left 2 columns: Applicant & Cancellation Details */}
+                  <div className='lg:col-span-2 space-y-6'>
+                    <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+                      <div className='flex items-center gap-3 px-6 py-5 border-b border-slate-100'>
+                        <div className='p-2.5 rounded-lg border border-blue-100 bg-blue-50 text-blue-600'>
+                          <UserRound className='w-5 h-5' />
+                        </div>
+                        <h3 className='font-bold text-slate-800 text-lg tracking-tight'>
+                          Applicant Information
+                        </h3>
+                      </div>
+                      <div className='grid gap-4 p-6 sm:grid-cols-2'>
+                        <DetailItem label='Applicant Name' value={applicantName} icon={UserRound} className='sm:col-span-2' />
+                        <DetailItem label='License Number' value={license.licenseNumber || request.licenseNumber} icon={ShieldCheck} mono />
+                        <DetailItem label='License ID' value={request.licenseId} icon={Fingerprint} mono />
+                      </div>
+                    </div>
+
+                    {/* Cancellation Details from the Cancellation API */}
+                    <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+                      <div className='flex items-center gap-3 px-6 py-5 border-b border-slate-100'>
+                        <div className='p-2.5 rounded-lg border border-red-100 bg-red-50 text-red-600'>
+                          <FileQuestion className='w-5 h-5' />
+                        </div>
+                        <h3 className='font-bold text-slate-800 text-lg tracking-tight'>
+                          Cancellation Details
+                        </h3>
+                      </div>
+                      <div className='grid gap-4 p-6 sm:grid-cols-2 lg:grid-cols-3'>
+                        <DetailItem label='Cancellation Reason' value={request.cancellationReason} icon={Info} className='sm:col-span-2 lg:col-span-3' />
+                        <DetailItem label='Requested By' value={request.requester?.username} icon={UserRound} />
+                        <DetailItem label='Requester Role' value={request.requester?.role?.name} icon={BadgeCheck} />
+                        <DetailItem label='Requested Date' value={fmtDate(request.requestedDate || request.createdAt)} icon={CalendarDays} />
+                        <DetailItem
+                          label='Current Workflow Status'
+                          value={request.workflowStatus?.name ? <StatusBadge status={request.workflowStatus} /> : (request.workflowStatus || request.status)}
+                          icon={Target}
+                        />
+                      </div>
+                      {request.remarks && (
+                        <div className='px-6 pb-6'>
+                          <div className='pt-4 border-t border-slate-100'>
+                            <p className='text-xs font-bold uppercase tracking-wide text-slate-400 mb-2'>Remarks</p>
+                            <p className='text-sm text-slate-700 whitespace-pre-line bg-slate-50 p-3 rounded-lg border border-slate-100'>{request.remarks}</p>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Right column: Workflow Timeline */}
+                  <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+                    <div className='flex items-center gap-3 px-6 py-5 border-b border-slate-100'>
+                      <div className='p-2.5 rounded-lg border border-amber-100 bg-amber-50 text-amber-600'>
+                        <History className='w-5 h-5' />
+                      </div>
+                      <h3 className='font-bold text-slate-800 text-lg tracking-tight'>
+                        Workflow Timeline
+                      </h3>
+                    </div>
+                    <div className='p-6'>
+                      <EnhancedApplicationTimeline
+                        application={request}
+                        workflowHistory={request.cancelWorkflowHistories || []}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Workflow History */}
+                {request.cancelWorkflowHistories && request.cancelWorkflowHistories.length > 0 && (
+                  <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+                    <div className='flex items-center gap-3 px-6 py-5 border-b border-slate-100'>
+                      <div className='p-2.5 rounded-lg border border-amber-100 bg-amber-50 text-amber-600'>
+                        <History className='w-5 h-5' />
+                      </div>
+                      <h3 className='font-bold text-slate-800 text-lg tracking-tight'>
+                        Workflow History
+                      </h3>
+                    </div>
+                    <div className='p-6 space-y-5'>
+                      {request.cancelWorkflowHistories.map((h: any, idx: number) => {
+                        const actionTaken = h?.actionTaken || 'Processed';
+                        const statusStyle = getStatusStyle(actionTaken);
+                        const borderColor = statusStyle.border;
+                        const backgroundColor = hexToRgba(borderColor, 0.05);
+                        const historyDate = h.createdAt ? new Date(h.createdAt) : new Date();
+                        const formattedDate = historyDate.toLocaleDateString('en-IN', {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric',
+                        });
+                        const formattedTime = historyDate.toLocaleTimeString('en-IN', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        });
+                        const previousUserName = h.previousUser?.username || 'Initiator';
+                        const previousRoleName = h.previousRole?.name || 'Role';
+                        const nextUserName = h.nextUser?.username;
+                        const nextRoleName = h.nextRole?.name;
+                        return (
+                          <div
+                            key={h.id ?? idx}
+                            className='border-l-4 pl-4 pr-4 py-3 rounded-r-lg'
+                            style={{ borderLeftColor: borderColor, backgroundColor }}
+                          >
+                            <div className='flex items-start justify-between'>
+                              <div className='flex-1'>
+                                <p className='font-semibold text-gray-900 text-sm'>{previousUserName}</p>
+                                <p className='text-xs text-gray-600 mt-0.5'>{previousRoleName}</p>
+                                <p className='text-sm text-gray-700 font-medium mt-1'>{actionTaken}</p>
+                                {nextUserName && (
+                                  <p className='text-xs text-gray-600 mt-1'>
+                                    → Forwarded to: <span className='font-medium'>{nextUserName}</span> ({nextRoleName})
+                                  </p>
+                                )}
+                                <p className='text-xs text-gray-500 mt-1 flex items-center'>
+                                  <Clock3 className='w-3 h-3 mr-1' />
+                                  {formattedDate} {formattedTime}
+                                </p>
+                              </div>
+                            </div>
+                            {h.remarks && (
+                              <div className='mt-3 p-4 bg-white rounded-lg border border-gray-200 shadow-sm'>
+                                <div className='text-base font-semibold text-gray-800 mb-3'>Remarks</div>
+                                <div className='flex text-sm text-gray-700 leading-relaxed whitespace-pre-line'>
+                                  <RichTextDisplay content={h.remarks} />
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+
+        {/* Original License Details tab: data from the License GET API (lazy loaded). */}
+        {activeTab === 'original' && (
+          <OriginalLicenseDetails
+            licenseData={licenseData}
+            licenseId={request.licenseId}
+            licenseNumber={request.Licenses?.licenseNumber || request.licenseNumber}
+          />
+        )}
     </div>
   );
 }
 
-const InfoCard: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
-  <div className='rounded-2xl bg-slate-50 px-4 py-4'>
-    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>{label}</p>
-    <p className='mt-2 text-sm font-medium text-slate-900 break-words'>{value}</p>
-  </div>
-);
+/**
+ * Original License Details tab content.
+ * Renders only data returned by the License GET API (GET /api/licenses/:licenseId).
+ * No Fresh Application API is used.
+ */
+function OriginalLicenseDetails({ licenseData, licenseId, licenseNumber }: {
+  licenseData: any;
+  licenseId?: number | string | null;
+  licenseNumber?: string | null;
+}) {
+  const license = licenseData || {};
+  const applicantName = [license.firstName, license.middleName, license.lastName]
+    .filter(Boolean)
+    .join(' ') || 'N/A';
+  const weapons = Array.isArray(license.requestedWeapons)
+    ? license.requestedWeapons.map((w: any) => w.name || w).join(', ')
+    : '';
+
+  return (
+    <>
+      {/* Key identifiers from the License API */}
+      <div className='rounded-3xl bg-white shadow-xl border border-slate-200 overflow-hidden'>
+        <div className='grid gap-6 p-6 md:grid-cols-3'>
+          <DetailItem label='License ID' value={license.id ?? licenseId} icon={Fingerprint} mono />
+          <DetailItem label='License Number' value={license.licenseNumber ?? licenseNumber} icon={ShieldCheck} mono />
+          <DetailItem label='Applicant Name' value={applicantName} icon={UserRound} />
+          <DetailItem label='License Status' value={license.status ? <StatusBadge status={license.status} /> : 'N/A'} icon={BadgeCheck} />
+          <DetailItem label='License Type' value={license.licenseType || 'Weapon'} icon={Target} />
+          <DetailItem label='Issue Date' value={fmtDate(license.issueDate)} icon={CalendarDays} />
+          <DetailItem label='Expiry Date' value={fmtDate(license.expiryDate)} icon={CalendarDays} />
+        </div>
+      </div>
+
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch'>
+        <SectionCard title='License Details' icon={Shield} iconColorClass='text-blue-600 bg-blue-50 border-blue-100'>
+          <div className='space-y-4 flex-1'>
+            <DetailItem label='Need for License' value={license.needForLicense} icon={Target} />
+            <DetailItem label='Arms Category' value={license.armsCategory} icon={ShieldCheck} />
+            <DetailItem label='Requested Weapons' value={weapons} icon={Crosshair} />
+            <DetailItem label='Area of Validity' value={license.areaOfValidity} icon={MapPin} />
+            <DetailItem label='Place / Area' value={license.licencedPlaceArea} icon={LocateFixed} />
+            <DetailItem label='Ammunition' value={license.ammunitionDescription} icon={Package} />
+          </div>
+        </SectionCard>
+
+        <SectionCard title='License History' icon={History} iconColorClass='text-amber-600 bg-amber-50 border-amber-100'>
+          <div className='space-y-4 flex-1'>
+            <DetailItem label='Previously Applied' value={yn(license.hasAppliedBefore)} icon={ClipboardCheck} />
+            <DetailItem label='Previous Result' value={license.previousResult} icon={BadgeCheck} />
+            <DetailItem label='Previous Authority' value={license.previousAuthorityName} icon={Building2} />
+            <DetailItem label='License Suspended' value={yn(license.hasLicenceSuspended)} icon={ShieldAlert} />
+            <DetailItem label='Suspension Reason' value={license.suspensionReason} icon={AlertTriangle} />
+            <DetailItem label='Family License' value={yn(license.hasFamilyLicence)} icon={Users} />
+          </div>
+        </SectionCard>
+
+        <SectionCard title='Criminal History' icon={TriangleAlert} iconColorClass='text-red-600 bg-red-50 border-red-100'>
+          <div className='space-y-4 flex-1'>
+            <DetailItem label='Convicted' value={yn(license.isConvicted)} icon={Ban} />
+            <DetailItem label='Bond Executed' value={yn(license.isBondExecuted)} icon={FileWarning} />
+            <DetailItem label='Prohibited' value={yn(license.isProhibited)} icon={Scale} />
+            {Array.isArray(license.firDetails) && license.firDetails.length > 0 && (
+              <div className='mt-4 pt-4 border-t border-slate-100'>
+                <p className='text-xs font-bold uppercase tracking-wide text-slate-400 mb-2'>FIR Details</p>
+                {license.firDetails.map((fir: any, i: number) => (
+                  <div key={i} className='bg-slate-50 border border-slate-100 rounded-xl p-3 text-xs mb-2 break-words'>
+                    {typeof fir === 'string' ? fir : JSON.stringify(fir)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch'>
+        {(() => {
+          const present = license.presentAddress || {};
+          return (
+            <SectionCard title='Present Address' icon={MapPin} iconColorClass='text-purple-600 bg-purple-50 border-purple-100'>
+              <div className='space-y-4 flex-1'>
+                <p className='text-sm text-slate-800 bg-slate-50 p-3 rounded-lg border border-slate-100 mb-3'>{present.addressLine}</p>
+                <DetailItem label='District' value={present.district?.name} icon={MapPin} />
+                <DetailItem label='State' value={present.state?.name} icon={MapPin} />
+                <DetailItem label='Police Station' value={present.policeStation?.name} icon={Building} />
+                <DetailItem label='Since Residing' value={fmtDate(present.sinceResiding)} icon={CalendarDays} />
+                <DetailItem label='Mobile' value={present.officeMobileNumber} icon={FileText} />
+              </div>
+            </SectionCard>
+          );
+        })()}
+        {(() => {
+          const permanent = license.permanentAddress || {};
+          return (
+            <SectionCard title='Permanent Address' icon={MapPin} iconColorClass='text-indigo-600 bg-indigo-50 border-indigo-100'>
+              <div className='space-y-4 flex-1'>
+                <p className='text-sm text-slate-800 bg-slate-50 p-3 rounded-lg border border-slate-100 mb-3'>{permanent.addressLine}</p>
+                <DetailItem label='District' value={permanent.district?.name} icon={MapPin} />
+                <DetailItem label='State' value={permanent.state?.name} icon={MapPin} />
+                <DetailItem label='Police Station' value={permanent.policeStation?.name} icon={Building} />
+                <DetailItem label='Since Residing' value={fmtDate(permanent.sinceResiding)} icon={CalendarDays} />
+                <DetailItem label='Mobile' value={permanent.officeMobileNumber} icon={FileText} />
+              </div>
+            </SectionCard>
+          );
+        })()}
+        {(() => {
+          const occ = license.occupationAndBusiness || {};
+          return (
+            <SectionCard title='Occupation & Business' icon={BriefcaseBusiness} iconColorClass='text-teal-600 bg-teal-50 border-teal-100'>
+              <div className='space-y-4 flex-1'>
+                <DetailItem label='Occupation' value={occ.occupation} icon={BriefcaseBusiness} />
+                <DetailItem label='Office Address' value={occ.officeAddress} icon={Building2} />
+                <DetailItem label='Crop Location' value={occ.cropLocation} icon={LocateFixed} />
+                {occ.areaUnderCultivation && (
+                  <DetailItem label='Area Under Cultivation' value={`${occ.areaUnderCultivation} Acres`} icon={FileText} />
+                )}
+                <DetailItem label='State' value={occ.state?.name} icon={MapPin} />
+                <DetailItem label='District' value={occ.district?.name} icon={MapPin} />
+              </div>
+            </SectionCard>
+          );
+        })()}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/cancelForm/CancelRequestModal.tsx
+++ b/frontend/src/components/cancelForm/CancelRequestModal.tsx
@@ -13,7 +13,7 @@ interface CancelRequestModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
-  prefillApplicationId?: string;
+  prefillLicenseId?: string;
 }
 
 type VerificationStep = 'ENTER_APP_ID' | 'VERIFYING_BIOMETRICS' | 'VERIFIED' | 'FAILED';
@@ -22,7 +22,7 @@ export default function CancelRequestModal({
   isOpen,
   onClose,
   onSuccess,
-  prefillApplicationId,
+  prefillLicenseId,
 }: CancelRequestModalProps) {
 
   const [loading, setLoading] = useState(false);
@@ -34,7 +34,7 @@ export default function CancelRequestModal({
   const [applicantDetails, setApplicantDetails] = useState<{
     name: string;
     licenseNumber: string;
-    applicationId: string;
+    licenseId: string;
   } | null>(null);
   const [biometricTargetThumb, setBiometricTargetThumb] = useState<string | null>(null);
   const [enrolledTemplates, setEnrolledTemplates] = useState<any[]>([]);
@@ -53,7 +53,7 @@ export default function CancelRequestModal({
   const [checkingExisting, setCheckingExisting] = useState(false);
 
   const [formData, setFormData] = useState({
-    applicationId: prefillApplicationId || '',
+    licenseId: prefillLicenseId || '',
     applicationType: 'FreshApplication',
     cancellationReason: '',
     remarks: '',
@@ -63,7 +63,7 @@ export default function CancelRequestModal({
   useEffect(() => {
     if (isOpen) {
       setFormData({
-        applicationId: prefillApplicationId || '',
+        licenseId: prefillLicenseId || '',
         applicationType: 'FreshApplication',
         cancellationReason: '',
         remarks: '',
@@ -84,13 +84,13 @@ export default function CancelRequestModal({
       setCapturingStep('');
       setVerificationStatus('ENTER_APP_ID');
     }
-  }, [isOpen, prefillApplicationId]);
+  }, [isOpen, prefillLicenseId]);
 
   useEffect(() => {
-    if (prefillApplicationId && isOpen) {
-      checkBiometricRequirement(prefillApplicationId);
+    if (prefillLicenseId && isOpen) {
+      checkBiometricRequirement(prefillLicenseId);
     }
-  }, [prefillApplicationId, isOpen]);
+  }, [prefillLicenseId, isOpen]);
 
   const checkDeviceConnection = async () => {
     try {
@@ -124,12 +124,12 @@ export default function CancelRequestModal({
     );
   };
 
-  const checkIfCancelExists = async (freshLicenseId: number): Promise<{ id: number; status: string } | null> => {
+  const checkIfCancelExists = async (licenseId: number): Promise<{ id: number; status: string } | null> => {
     try {
       setCheckingExisting(true);
       // First check for PENDING cancel request
       const pendingResponse = await CancelService.getCancelRequests({
-        freshLicenseId,
+        licenseId,
         status: 'PENDING',
       });
       const pendingData = pendingResponse?.data || [];
@@ -139,7 +139,7 @@ export default function CancelRequestModal({
 
       // Also check for APPROVED cancel request (application already cancelled)
       const approvedResponse = await CancelService.getCancelRequests({
-        freshLicenseId,
+        licenseId,
         status: 'APPROVED',
       });
       const approvedData = approvedResponse?.data || [];
@@ -155,32 +155,32 @@ export default function CancelRequestModal({
     }
   };
 
-  const checkBiometricRequirement = async (appId: string) => {
+  const checkBiometricRequirement = async (licenseIdentifier: string) => {
     try {
       setVerificationChecking(true);
       setVerificationError(null);
 
       // First check if a cancel request already exists (pending or approved)
-      const existing = await checkIfCancelExists(Number(appId));
+      const existing = await checkIfCancelExists(Number(licenseIdentifier));
       if (existing) {
         setExistingCancel(existing);
         setVerificationStatus('FAILED');
         if (existing.status === 'PENDING') {
-          setVerificationError('A pending cancel request already exists for this application.');
+          setVerificationError('A pending cancel request already exists for this license.');
         } else if (existing.status === 'APPROVED') {
-          setVerificationError('This application has already been cancelled.');
+          setVerificationError('This license has already been cancelled.');
         }
         setVerificationChecking(false);
         return;
       }
 
-      const response = await ApplicationService.getApplication(appId);
+      const response = await ApplicationService.getLicense(licenseIdentifier);
       const freshData = response?.data ?? response;
       if (!freshData) {
-        throw new Error('No application data found for the provided Application ID.');
+        throw new Error('No license data found for the provided License ID or License Number.');
       }
 
-      const numericAppId = String(freshData.id || freshData.applicationId || appId);
+      const numericLicenseId = String(freshData.licenseId || freshData.id || licenseIdentifier);
       const bioData = freshData.biometricData?.biometricData || freshData.biometricData || null;
       const fingerprints = bioData?.fingerprints || [];
 
@@ -189,7 +189,7 @@ export default function CancelRequestModal({
         .map((f: any) => ({
           template: f.template,
           fingerPosition: f.position,
-          applicationId: numericAppId,
+          licenseId: numericLicenseId,
         }));
 
       const name =
@@ -200,9 +200,10 @@ export default function CancelRequestModal({
       const details = {
         name,
         licenseNumber: getLicenseNumber(freshData),
-        applicationId: numericAppId,
+        licenseId: numericLicenseId,
       };
       setApplicantDetails(details);
+      setFormData(prev => ({ ...prev, licenseId: numericLicenseId }));
 
       if (userThumbprints.length > 0) {
         setEnrolledTemplates(userThumbprints);
@@ -323,8 +324,8 @@ export default function CancelRequestModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formData.applicationId || !formData.cancellationReason) {
-      toast.error('Please provide the application target ID and reason');
+    if (!formData.licenseId || !formData.cancellationReason) {
+      toast.error('Please provide the license target ID and reason');
       return;
     }
 
@@ -334,8 +335,9 @@ export default function CancelRequestModal({
     try {
       setLoading(true);
       const payload = {
-        freshLicenseId: Number(formData.applicationId),
+        licenseId: Number(formData.licenseId),
         applicationType: 'Cancel Application',
+        applicantName: applicantDetails?.name || '',
         cancellationReason: formData.cancellationReason,
         remarks: formData.remarks,
       };
@@ -349,18 +351,18 @@ export default function CancelRequestModal({
       // Handle "pending cancel request already exists" error gracefully
       const message = error?.response?.data?.message || error?.message || 'Failed to submit cancellation request';
       if (message.includes('pending cancel request already exists')) {
-        toast.error('A cancellation request has already been submitted for this application. Please process the existing request first.');
+        toast.error('A cancellation request has already been submitted for this license. Please process the existing request first.');
         setVerificationStatus('FAILED');
         setVerificationError('A pending cancel request already exists. You cannot create a duplicate.');
         // Try to find the existing request ID for navigation
-        const existing = await checkIfCancelExists(Number(formData.applicationId));
+        const existing = await checkIfCancelExists(Number(formData.licenseId));
         if (existing) {
           setExistingCancel(existing);
         }
       } else if (message.includes('already cancelled') || message.includes('already been cancelled')) {
-        toast.error('This application has already been cancelled.');
+        toast.error('This license has already been cancelled.');
         setVerificationStatus('FAILED');
-        setVerificationError('This application has already been cancelled.');
+        setVerificationError('This license has already been cancelled.');
       } else {
         toast.error(message);
       }
@@ -396,8 +398,8 @@ export default function CancelRequestModal({
                   <div>
                     <h4 className="text-sm font-semibold text-red-800">Cancel Request Already Exists</h4>
                     <p className="text-sm text-red-700 mt-1">
-                      A pending cancellation request (ID: #{existingCancel.id}) already exists for application{' '}
-                      <strong>#{formData.applicationId}</strong>. You cannot create a duplicate request.
+                      A pending cancellation request (ID: #{existingCancel.id}) already exists for license{' '}
+                      <strong>#{formData.licenseId}</strong>. You cannot create a duplicate request.
                     </p>
                   </div>
                 </div>
@@ -417,10 +419,10 @@ export default function CancelRequestModal({
                   </svg>
                   <div>
                     <h4 className="text-sm font-semibold text-blue-800">Application Already Cancelled</h4>
-                    <p className="text-sm text-blue-700 mt-1">
-                      The application <strong>#{formData.applicationId}</strong> has already been cancelled.
-                      No further cancellation requests can be raised for this application.
-                    </p>
+                      <p className="text-sm text-blue-700 mt-1">
+                        The license <strong>#{formData.licenseId}</strong> has already been cancelled.
+                        No further cancellation requests can be raised for this license.
+                      </p>
                   </div>
                 </div>
               </div>
@@ -448,7 +450,7 @@ export default function CancelRequestModal({
             )}
             {(isPending || isApproved) && (
               <a
-                href={`/application/${formData.applicationId}`}
+                href={`/licenses/${formData.licenseId}`}
                 className="inline-flex items-center gap-2 px-5 py-2.5 bg-gray-600 hover:bg-gray-700 text-white rounded-lg font-medium text-sm transition-colors shadow-sm"
               >
                 <ExternalLink className="w-4 h-4" />
@@ -495,20 +497,20 @@ export default function CancelRequestModal({
             <div>
               <p className="text-sm font-medium text-amber-800">Verification Required</p>
               <p className="text-xs text-amber-700 mt-1">
-                Enter the Application ID to look up the applicant and perform verification before creating a cancel request.
+                Enter the License ID or License Number to look up the applicant and perform verification before creating a cancel request.
               </p>
             </div>
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              Fresh Application ID
+              License ID / License Number
             </label>
             <input
-              type="number"
-              placeholder="Enter Fresh Application ID"
+              type="text"
+              placeholder="Enter License ID or License Number"
               className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-alms-navy/20 focus:border-alms-navy outline-none transition-all text-sm"
-              value={formData.applicationId}
-              onChange={(e) => setFormData((prev) => ({ ...prev, applicationId: e.target.value }))}
+              value={formData.licenseId}
+              onChange={(e) => setFormData((prev) => ({ ...prev, licenseId: e.target.value }))}
             />
           </div>
           {verificationError && (
@@ -518,8 +520,8 @@ export default function CancelRequestModal({
             </div>
           )}
           <button
-            onClick={() => checkBiometricRequirement(formData.applicationId)}
-            disabled={!formData.applicationId}
+            onClick={() => checkBiometricRequirement(formData.licenseId)}
+            disabled={!formData.licenseId}
             className="w-full px-5 py-2.5 bg-alms-navy hover:bg-alms-navy-dark text-white rounded-lg font-medium text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
           >
             Check Application
@@ -546,8 +548,8 @@ export default function CancelRequestModal({
                 <span className="text-gray-800 font-semibold">{applicantDetails.name}</span>
               </div>
               <div className="flex justify-between items-center text-sm">
-                <span className="text-gray-500 font-medium">Application ID</span>
-                <span className="text-gray-800 font-semibold">{applicantDetails.applicationId}</span>
+                <span className="text-gray-500 font-medium">License ID</span>
+                <span className="text-gray-800 font-semibold">{applicantDetails.licenseId}</span>
               </div>
               <div className="flex justify-between items-center text-sm">
                 <span className="text-gray-500 font-medium">License Number</span>
@@ -627,18 +629,18 @@ export default function CancelRequestModal({
     <form onSubmit={handleSubmit} className="space-y-5">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
         <div className="space-y-1.5">
-          <label htmlFor="modal-applicationId" className="block text-sm font-medium text-gray-700">
-            Target Application ID
+          <label htmlFor="modal-licenseId" className="block text-sm font-medium text-gray-700">
+            Target License ID
           </label>
           <input
-            type="number"
-            id="modal-applicationId"
-            name="applicationId"
-            value={formData.applicationId}
+            type="text"
+            id="modal-licenseId"
+            name="licenseId"
+            value={formData.licenseId}
             disabled
             className="w-full px-4 py-2.5 border border-gray-300 rounded-lg bg-gray-50 cursor-not-allowed text-gray-700 font-medium text-sm"
           />
-          <p className="text-xs text-gray-400">Verified target ID of the application.</p>
+          <p className="text-xs text-gray-400">Verified target ID of the license.</p>
         </div>
 
         <div className="space-y-1.5">

--- a/frontend/src/components/cancelForm/SubmitCancelForm.tsx
+++ b/frontend/src/components/cancelForm/SubmitCancelForm.tsx
@@ -10,18 +10,18 @@ import toast from 'react-hot-toast';
 export default function SubmitCancelForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const urlApplicationId = searchParams?.get('applicationId') || '';
+  const urlLicenseId = searchParams?.get('licenseId') || '';
 
   const [loading, setLoading] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
   const [verificationChecking, setVerificationChecking] = useState(false);
   const [verificationStatus, setVerificationStatus] = useState<'ENTER_APP_ID' | 'VERIFYING_BIOMETRICS' | 'VERIFIED' | 'FAILED'>('ENTER_APP_ID');
   const [verificationError, setVerificationError] = useState<string | null>(null);
-  
+
   const [applicantDetails, setApplicantDetails] = useState<{
     name: string;
     licenseNumber: string;
-    applicationId: string;
+    licenseId: string;
   } | null>(null);
   const [biometricTargetThumb, setBiometricTargetThumb] = useState<string | null>(null);
   const [enrolledTemplates, setEnrolledTemplates] = useState<any[]>([]);
@@ -37,20 +37,20 @@ export default function SubmitCancelForm() {
   const [capturingStep, setCapturingStep] = useState<string>('');
 
   const [formData, setFormData] = useState({
-    applicationId: urlApplicationId,
+    licenseId: urlLicenseId,
     applicationType: 'FreshApplication',
     cancellationReason: '',
     remarks: ''
   });
 
   useEffect(() => {
-    if (urlApplicationId) {
-      setFormData(prev => ({ ...prev, applicationId: urlApplicationId }));
-      checkBiometricRequirement(urlApplicationId);
+    if (urlLicenseId) {
+      setFormData(prev => ({ ...prev, licenseId: urlLicenseId }));
+      checkBiometricRequirement(urlLicenseId);
     } else {
       setVerificationStatus('ENTER_APP_ID');
     }
-  }, [urlApplicationId]);
+  }, [urlLicenseId]);
 
   const checkDeviceConnection = async () => {
     try {
@@ -84,18 +84,18 @@ export default function SubmitCancelForm() {
     );
   };
 
-  const checkBiometricRequirement = async (appId: string) => {
+  const checkBiometricRequirement = async (licenseIdentifier: string) => {
     try {
       setVerificationChecking(true);
       setVerificationError(null);
 
-      const response = await ApplicationService.getApplication(appId);
+      const response = await ApplicationService.getLicense(licenseIdentifier);
       const freshData = response?.data ?? response;
       if (!freshData) {
-        throw new Error('No application data found for the provided Application ID.');
+        throw new Error('No license data found for the provided License ID or License Number.');
       }
 
-      const numericAppId = String(freshData.id || freshData.applicationId || appId);
+      const numericLicenseId = String(freshData.licenseId || freshData.id || licenseIdentifier);
       const bioData = freshData.biometricData?.biometricData || freshData.biometricData || null;
       const fingerprints = bioData?.fingerprints || [];
 
@@ -104,7 +104,7 @@ export default function SubmitCancelForm() {
         .map((f: any) => ({
           template: f.template,
           fingerPosition: f.position,
-          applicationId: numericAppId
+          licenseId: numericLicenseId
         }));
 
       const name = [
@@ -116,9 +116,10 @@ export default function SubmitCancelForm() {
       const details = {
         name,
         licenseNumber: getLicenseNumber(freshData),
-        applicationId: numericAppId
+        licenseId: numericLicenseId
       };
       setApplicantDetails(details);
+      setFormData(prev => ({ ...prev, licenseId: numericLicenseId }));
 
       if (userThumbprints.length > 0) {
         setEnrolledTemplates(userThumbprints);
@@ -131,7 +132,7 @@ export default function SubmitCancelForm() {
         setVerificationStatus('VERIFIED');
       }
     } catch (err: any) {
-      setVerificationError(err?.message || 'Failed to fetch application details.');
+      setVerificationError(err?.message || 'Failed to fetch license details.');
       setVerificationStatus('ENTER_APP_ID');
     } finally {
       setVerificationChecking(false);
@@ -239,8 +240,8 @@ export default function SubmitCancelForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formData.applicationId || !formData.cancellationReason) {
-      toast.error('Please provide the application target ID and reason');
+    if (!formData.licenseId || !formData.cancellationReason) {
+      toast.error('Please provide the license target ID and reason');
       return;
     }
 
@@ -250,8 +251,9 @@ export default function SubmitCancelForm() {
     try {
       setLoading(true);
       const payload = {
-        freshLicenseId: Number(formData.applicationId),
+        licenseId: Number(formData.licenseId),
         applicationType: 'Cancel Application', // Always matching request payload format "Cancel Application"
+        applicantName: applicantDetails?.name || '',
         cancellationReason: formData.cancellationReason,
         remarks: formData.remarks
       };
@@ -280,20 +282,20 @@ export default function SubmitCancelForm() {
     return (
       <div className='max-w-2xl mx-auto w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8'>
         <h2 className='text-2xl font-bold text-gray-900 mb-4'>Verification Required</h2>
-        <p className='text-sm text-gray-500 mb-6'>Please load the target Application ID through the header menu or enter it here to perform verification.</p>
+        <p className='text-sm text-gray-500 mb-6'>Please load the target License ID through the header menu or enter it here to perform verification.</p>
         <div className='space-y-4'>
           <input
-            type='number'
-            placeholder='Enter Fresh Application ID'
+            type='text'
+            placeholder='Enter License ID or License Number'
             className='w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-red-500 focus:border-red-500'
-            value={formData.applicationId}
-            onChange={(e) => setFormData(prev => ({ ...prev, applicationId: e.target.value }))}
+            value={formData.licenseId}
+            onChange={(e) => setFormData(prev => ({ ...prev, licenseId: e.target.value }))}
           />
           <button
-            onClick={() => checkBiometricRequirement(formData.applicationId)}
+            onClick={() => checkBiometricRequirement(formData.licenseId)}
             className='px-6 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md font-medium'
           >
-            Check Application
+            Check License
           </button>
           {verificationError && <p className='text-sm text-red-600 mt-2'>{verificationError}</p>}
         </div>
@@ -316,8 +318,8 @@ export default function SubmitCancelForm() {
               <span className="text-gray-800 font-semibold">{applicantDetails.name}</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-gray-500 font-medium">Application ID</span>
-              <span className="text-gray-800 font-semibold">{applicantDetails.applicationId}</span>
+              <span className="text-gray-500 font-medium">License ID</span>
+              <span className="text-gray-800 font-semibold">{applicantDetails.licenseId}</span>
             </div>
             <div className="flex justify-between text-sm">
               <span className="text-gray-500 font-medium">License Number</span>
@@ -425,18 +427,18 @@ export default function SubmitCancelForm() {
         <form onSubmit={handleSubmit} className='space-y-6'>
           <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
             <div className='space-y-2'>
-               <label htmlFor='applicationId' className='block text-sm font-semibold text-gray-700'>
-                 Target Application ID
+               <label htmlFor='licenseId' className='block text-sm font-semibold text-gray-700'>
+                 Target License ID
                </label>
                <input
-                 type='number'
-                 id='applicationId'
-                 name='applicationId'
-                 value={formData.applicationId}
+                 type='text'
+                 id='licenseId'
+                 name='licenseId'
+                 value={formData.licenseId}
                  disabled
                  className='w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 cursor-not-allowed text-gray-700 font-medium'
                />
-               <p className='text-xs text-gray-500'>Verified target ID of the application.</p>
+               <p className='text-xs text-gray-500'>Verified target ID of the license.</p>
             </div>
 
             <div className='space-y-2'>

--- a/frontend/src/components/forms/renewal/RenewalSummary.tsx
+++ b/frontend/src/components/forms/renewal/RenewalSummary.tsx
@@ -27,8 +27,8 @@ const RenewalSummary: React.FC<{ licenseId?: string; renewalId?: string; data?: 
 
   return (
     <div className='flex gap-4 overflow-x-auto py-2'>
-      <Card label='License ID' value={licenseId || data?.licenseId || data?.freshLicenseId || '—'} />
-      <Card label='Renewal ID' value={displayId} />
+      <Card label='License ID' value={licenseId || data?.licenseId || '—'} />
+      <Card label='Fresh Acknowledgement No' value={displayId} />
       <Card label='Applicant' value={applicantName} />
       <Card label='License No' value={data?.licenseNumber || '—'} />
       <Card label='Status' value={getStatusLabel(data)} />

--- a/frontend/src/components/forms/renewal/sections/BiometricInformation.tsx
+++ b/frontend/src/components/forms/renewal/sections/BiometricInformation.tsx
@@ -1432,7 +1432,7 @@ const BiometricInformation = forwardRef(function BiometricInformation(
                 <h3 className='text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide'>Existing Record Details</h3>
                 <div className='space-y-3'>
                   <div className='flex items-center justify-between py-2 border-b border-gray-200'>
-                    <span className='text-sm text-gray-600'>Application ID</span>
+                    <span className='text-sm text-gray-600'>License ID</span>
                     <span className='text-sm font-semibold text-gray-900'>{duplicateMatchInfo.applicationId}</span>
                   </div>
                   {duplicateMatchInfo.almsLicenseId && (


### PR DESCRIPTION
### Today's Summary

* Updated the **Renewal** module to use `licenseId` and `licenseNumber` throughout the flow and POST/PATCH APIs.
* Switched the Renewal flow to use **License APIs only**, added existing renewal checks, and optimized API calls to prevent duplicates.
* Changed the Renewal form to **manual section completion** and fixed API mapping issues (`wildBeastsSpecification`, `placeOfBirth`).
* Updated the **Cancellation** module to use `licenseId` and `licenseNumber`, and renamed **"Original Application Details"** to **"License Details"**.
* Updated the **Cancellation Details** page to fetch data from the Cancellation and License APIs, load Application History using License API data, improve License Details mapping, redesign the layout, and optimize API calls.
