### PR TITLE
Feat/cancel flow

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -733,7 +733,7 @@ model Licenses {
   aadharNumber               String?
   panNumber                  String?
   validFrom                  DateTime
-  validTill                  DateTime
+  validTill                  DateTime?
   armsCategory               ArmsCategory?
   areaOfValidity             String?
   ammunitionDescription      String?

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -774,7 +774,10 @@ model Licenses {
   renewalApplication           RenewalFormPersonalDetails?             @relation("LicenseToRenewalApp", fields: [renewalApplicationId], references: [id])
   cancelApplicationId          Int?
   cancelApplication            CancelFormRequests?                     @relation("LicenseToCancelApp", fields: [cancelApplicationId], references: [id])
+  lastModifiedAppId          Int?
   lastModifiedAppType          String?
+  previousModifiedAppType      String?
+  previousModifiedAppId        Int?
   renewalCount                 Int                                      @default(0)
   createdAt                    DateTime                                 @default(now())
   updatedAt                    DateTime                                 @updatedAt

--- a/backend/src/modules/CancelForm/cancel-form.controller.ts
+++ b/backend/src/modules/CancelForm/cancel-form.controller.ts
@@ -130,6 +130,7 @@ export class CancelFormController {
         limit: limit ? Number(limit) : undefined,
         requestedBy: requestedBy ? Number(requestedBy) : undefined,
         licenseId: licenseId ? Number(licenseId) : undefined,
+        status: status || undefined,
       });
 
       return {

--- a/backend/src/modules/CancelForm/cancel-form.service.ts
+++ b/backend/src/modules/CancelForm/cancel-form.service.ts
@@ -619,12 +619,18 @@ export class CancelFormService {
             data: cancelUpdateData,
           });
 
-          // Capture the license's current status BEFORE the update so the workflow
-          // history accurately reflects the previous state (prevents reading back
-          // the already-updated CANCELLED status within the same transaction).
+          // Capture the license's current status and tracking fields BEFORE the update
+          // so the workflow history and previous-modified tracking are accurate.
           const licenseBeforeCancel = await tx.licenses.findUnique({
             where: { id: cancelRequest.licenseId },
-            select: { status: true },
+            select: {
+              status: true,
+              lastModifiedAppType: true,
+              lastModifiedAppId: true,
+              lastModifiedRenewalId: true,
+              renewalApplicationId: true,
+              freshApplicationId: true,
+            },
           });
 
           // 2. Update the license with cancellation metadata
@@ -639,7 +645,15 @@ export class CancelFormService {
               cancellationReason: cancelRequest.cancellationReason,
               cancellationDate: new Date(),
               cancelApplicationId: cancelRequest.id,
+              // Shift current → previous tracking
+              previousModifiedAppType: licenseBeforeCancel?.lastModifiedAppType,
+              previousModifiedAppId: licenseBeforeCancel?.lastModifiedAppId ?? (
+                (licenseBeforeCancel?.lastModifiedAppType || '').toUpperCase() === 'FRESH'
+                  ? licenseBeforeCancel?.freshApplicationId
+                  : licenseBeforeCancel?.lastModifiedRenewalId ?? licenseBeforeCancel?.renewalApplicationId
+              ),
               lastModifiedAppType: 'CANCELLATION',
+              lastModifiedAppId: cancelRequest.id,
             },
           });
 

--- a/backend/src/modules/CancelForm/cancel-form.service.ts
+++ b/backend/src/modules/CancelForm/cancel-form.service.ts
@@ -32,9 +32,36 @@ export class CancelFormService {
       });
       
       console.log('currentUserId:', currentUserId);
+
       // Wrap creation and workflow history in a transaction for atomicity.
-      // The duplicate check runs INSIDE the transaction so it is atomic with the INSERT.
+      // The CANCELLED status check runs INSIDE the transaction so it is atomic with the INSERT.
       const cancelRequest = await prisma.$transaction(async (tx: any) => {
+        // Check if the license has been CANCELLED (inside transaction for atomicity)
+        const targetLicense = await tx.licenses.findUnique({
+          where: { id: dto.licenseId },
+          select: { status: true },
+        });
+
+        if (targetLicense && targetLicense.status === 'CANCELLED') {
+          throw new BadRequestException(
+            'Cannot create a cancellation request for a cancelled license. This license has been permanently cancelled and no further actions are allowed.',
+          );
+        }
+
+        // Check if a PENDING cancellation request already exists for this license
+        const existingPending = await tx.cancelFormRequests.findFirst({
+          where: {
+            licenseId: dto.licenseId,
+            actionedDate: null,
+          },
+          select: { id: true },
+        });
+
+        if (existingPending) {
+          throw new BadRequestException(
+            'A cancellation request for this license already exists and is pending approval.',
+          );
+        }
 
         // generate a unique acknowledgement number for the cancel request
         const acknowledgementNo = `CAF${Date.now()}${Math.floor(Math.random() * 1000)}`;
@@ -278,6 +305,7 @@ export class CancelFormService {
     limit?: number;
     requestedBy?: number;
     licenseId?: number;
+    status?: string;
   }): Promise<{ data: any[]; total: number; page: number; limit: number }> {
     try {
       const page = Math.max(Number(filters.page ?? 1), 1);
@@ -291,6 +319,13 @@ export class CancelFormService {
       }
       if (filters.licenseId) {
         where.licenseId = filters.licenseId;
+      }
+      if (filters.status) {
+        if (filters.status === 'PENDING') {
+          where.actionedDate = null;
+        } else if (filters.status === 'APPROVED') {
+          where.actionedDate = { not: null };
+        }
       }
 
       const [cancelRequests, total] = await Promise.all([

--- a/backend/src/modules/CancelForm/cancel-form.service.ts
+++ b/backend/src/modules/CancelForm/cancel-form.service.ts
@@ -619,11 +619,27 @@ export class CancelFormService {
             data: cancelUpdateData,
           });
 
-          // 2. Update the original license to CANCELLED status
+          // Capture the license's current status BEFORE the update so the workflow
+          // history accurately reflects the previous state (prevents reading back
+          // the already-updated CANCELLED status within the same transaction).
+          const licenseBeforeCancel = await tx.licenses.findUnique({
+            where: { id: cancelRequest.licenseId },
+            select: { status: true },
+          });
+
+          // 2. Update the license with cancellation metadata
+          // Only cancellation-relevant fields are updated — personal details,
+          // addresses, occupation, criminal history, documents, weapons,
+          // and other applicant data are preserved intact for audit/historical purposes.
           await tx.licenses.update({
             where: { id: cancelRequest.licenseId },
             data: {
               status: LicenseStatus.CANCELLED,
+              validTill: null,
+              cancellationReason: cancelRequest.cancellationReason,
+              cancellationDate: new Date(),
+              cancelApplicationId: cancelRequest.id,
+              lastModifiedAppType: 'CANCELLATION',
             },
           });
 
@@ -635,7 +651,7 @@ export class CancelFormService {
                 action: ACTION_CODES.CANCEL,
                 applicationId: cancelRequest.id,
                 applicationType: cancelRequest.applicationType,
-                previousStatus: application.status as any,
+                previousStatus: licenseBeforeCancel?.status ?? application.status,
                 newStatus: LicenseStatus.CANCELLED,
                 changedBy: currentUserId,
                 remarks: `Application cancelled. Reason: ${cancelRequest.cancellationReason}`,

--- a/backend/src/modules/FLAWorkflow/handlers/cancel-workflow.handler.ts
+++ b/backend/src/modules/FLAWorkflow/handlers/cancel-workflow.handler.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IWorkflowLifecycleHandler } from './workflow-lifecycle.interface';
+import { Prisma } from '@prisma/client';
+import { LicensesService } from '../../licenses/licenses.service';
+import { PrismaService } from '../../../services/prisma.service';
+
+@Injectable()
+export class CancelWorkflowHandler implements IWorkflowLifecycleHandler {
+  private readonly logger = new Logger(CancelWorkflowHandler.name);
+
+  constructor(
+    private readonly licensesService: LicensesService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async onFinalApproval(applicationId: number, currentUserId: number, tx: Prisma.TransactionClient): Promise<void> {
+    this.logger.debug(`Executing onFinalApproval for Cancel Request: ${applicationId}`);
+
+    // Fetch the cancel request details to get the licenseId and reason
+    const cancelRequest = await tx.cancelFormRequests.findUnique({
+      where: { id: applicationId },
+    });
+
+    if (!cancelRequest || !cancelRequest.licenseId) {
+      throw new Error(`Cancel request ${applicationId} not found or missing licenseId`);
+    }
+
+    // Delegate the actual license mutation logic to LicensesService
+    await this.licensesService.cancelLicense(
+      cancelRequest.licenseId,
+      cancelRequest.cancellationReason,
+      applicationId,
+      currentUserId,
+      tx,
+    );
+  }
+
+  async onFinalRejection(applicationId: number, currentUserId: number, tx: Prisma.TransactionClient): Promise<void> {
+    // Optionally handle any specific logic when a cancellation is rejected
+    this.logger.debug(`Executing onFinalRejection for Cancel Request: ${applicationId}`);
+  }
+}

--- a/backend/src/modules/FLAWorkflow/handlers/workflow-lifecycle.interface.ts
+++ b/backend/src/modules/FLAWorkflow/handlers/workflow-lifecycle.interface.ts
@@ -1,0 +1,6 @@
+import { Prisma } from '@prisma/client';
+
+export interface IWorkflowLifecycleHandler {
+  onFinalApproval(applicationId: number, currentUserId: number, tx: Prisma.TransactionClient): Promise<void>;
+  onFinalRejection(applicationId: number, currentUserId: number, tx: Prisma.TransactionClient): Promise<void>;
+}

--- a/backend/src/modules/FLAWorkflow/workflow.module.ts
+++ b/backend/src/modules/FLAWorkflow/workflow.module.ts
@@ -1,10 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { WorkflowController } from './workflow.controller';
 import { WorkflowController as WorkflowStatusesActionsController } from './workflow.statuses-actions.controller';
 import { WorkflowService } from './workflow.service';
+import { CancelWorkflowHandler } from './handlers/cancel-workflow.handler';
+import { LicensesModule } from '../licenses/licenses.module';
+import { PrismaService } from '../../services/prisma.service';
 
 @Module({
+  imports: [LicensesModule],
   controllers: [WorkflowController, WorkflowStatusesActionsController],
-  providers: [WorkflowService],
+  providers: [WorkflowService, CancelWorkflowHandler, PrismaService],
 })
 export class WorkflowModule {}

--- a/backend/src/modules/FLAWorkflow/workflow.service.ts
+++ b/backend/src/modules/FLAWorkflow/workflow.service.ts
@@ -439,6 +439,7 @@ export class WorkflowService {
           renewalCount: 0,
           issuedBy,
           lastModifiedAppType: 'FRESH',
+          lastModifiedAppId: appData.id,
           endorsedWeapons: licDetail?.requestedWeapons?.length
             ? { connect: licDetail.requestedWeapons.map((w: any) => ({ id: w.id })) }
             : undefined,
@@ -697,7 +698,15 @@ export class WorkflowService {
         renewalIds: {
           push: renewalApplicationId,
         },
+        // Shift current → previous tracking before updating
+        previousModifiedAppType: existingLicense.lastModifiedAppType,
+        previousModifiedAppId: existingLicense.lastModifiedAppId ?? (
+          (existingLicense.lastModifiedAppType || '').toUpperCase() === 'FRESH'
+            ? existingLicense.freshApplicationId
+            : existingLicense.lastModifiedRenewalId ?? existingLicense.renewalApplicationId
+        ),
         lastModifiedAppType: 'RENEWAL',
+        lastModifiedAppId: renewalApplicationId,
         status: LicenseStatus.ACTIVE,
 
         // Update endorsed weapons

--- a/backend/src/modules/FLAWorkflow/workflow.service.ts
+++ b/backend/src/modules/FLAWorkflow/workflow.service.ts
@@ -1,11 +1,15 @@
-import { Injectable, ForbiddenException, NotFoundException, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, ForbiddenException, NotFoundException, BadRequestException, InternalServerErrorException, Inject, forwardRef } from '@nestjs/common';
 import prisma from '../../db/prismaClient';
 import { LicenseStatus } from '@prisma/client';
 import { ForwardDto } from './dto/forward.dto';
 import { TERMINAL_ACTIONS, FORWARD_ACTIONS, ACTION_CODES, isTerminalAction, isForwardAction, isApprovalAction, isRejectionAction,  isReEnquiryAction, isRecommendAction, isNotRecommendAction } from '../../constants/workflow-actions';
+import { CancelWorkflowHandler } from './handlers/cancel-workflow.handler';
 
 @Injectable()
 export class WorkflowService {
+  constructor(
+    private readonly cancelWorkflowHandler: CancelWorkflowHandler,
+  ) {}
 
   async getStatusesAndActions(id?: number) {
     if (id) {
@@ -938,33 +942,12 @@ export class WorkflowService {
           }
         }
 
-        // === LICENSE HOOK: Cancel the license record itself ===
+        // === LICENSE HOOK: Delegate to handler ===
         try {
-          await tx.licenses.update({
-            where: { id: cancelRequest.licenseId },
-            data: {
-              status: LicenseStatus.CANCELLED,
-              cancellationReason: cancelRequest.cancellationReason,
-              cancellationDate: new Date(),
-              cancelApplicationId: payload.applicationId,
-              lastModifiedAppType: 'CANCELLATION',
-            },
-          });
-
-          await tx.licenseWorkflowHistory.create({
-            data: {
-              licenseId: cancelRequest.licenseId,
-              action: 'CANCELLED',
-              applicationId: payload.applicationId,
-              applicationType: 'CANCELLATION',
-              previousStatus: LicenseStatus.ACTIVE,
-              newStatus: LicenseStatus.CANCELLED,
-              changedBy: payload.currentUserId,
-              remarks: `License cancelled. Reason: ${cancelRequest.cancellationReason}`,
-            },
-          });
+          await this.cancelWorkflowHandler.onFinalApproval(payload.applicationId, payload.currentUserId, tx);
         } catch (err) {
           console.error('[LicenseHook] Failed to cancel license:', err);
+          throw new InternalServerErrorException('Failed to update license record');
         }
       } else if (isRejectedAction) {
         actionTaken = ACTION_CODES.REJECT;

--- a/backend/src/modules/licenses/licenses.module.ts
+++ b/backend/src/modules/licenses/licenses.module.ts
@@ -6,5 +6,6 @@ import { PrismaService } from '../../services/prisma.service';
 @Module({
   controllers: [LicensesController],
   providers: [LicensesService, PrismaService],
+  exports: [LicensesService],
 })
 export class LicensesModule {}

--- a/backend/src/modules/licenses/licenses.service.ts
+++ b/backend/src/modules/licenses/licenses.service.ts
@@ -1364,6 +1364,13 @@ export class LicensesService {
     currentUserId: number,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
+    // Capture the license's current status BEFORE the update so the workflow
+    // history accurately reflects the previous state (fixes hardcoded ACTIVE bug).
+    const currentLicense = await tx.licenses.findUnique({
+      where: { id: licenseId },
+      select: { status: true },
+    });
+
     await tx.licenses.update({
       where: { id: licenseId },
       data: {
@@ -1382,7 +1389,7 @@ export class LicensesService {
         action: 'CANCELLED',
         applicationId,
         applicationType: 'CANCELLATION',
-        previousStatus: LicenseStatus.ACTIVE,
+        previousStatus: currentLicense?.status ?? LicenseStatus.ACTIVE,
         newStatus: LicenseStatus.CANCELLED,
         changedBy: currentUserId,
         remarks: `License cancelled. Reason: ${reason}`,

--- a/backend/src/modules/licenses/licenses.service.ts
+++ b/backend/src/modules/licenses/licenses.service.ts
@@ -377,6 +377,9 @@ export class LicensesService {
       renewalApplicationId: license.renewalApplicationId,
       cancelApplicationId: license.cancelApplicationId,
       lastModifiedAppType: license.lastModifiedAppType,
+      lastModifiedAppId: license.lastModifiedAppId ?? null,
+      previousModifiedAppType: license.previousModifiedAppType ?? null,
+      previousModifiedAppId: license.previousModifiedAppId ?? null,
       lastModifiedRenewalId: license.lastModifiedRenewalId ?? null,
       renewalIds: license.renewalIds ?? [],
     };
@@ -871,6 +874,7 @@ export class LicensesService {
           // === TRACKING ===
           renewalCount: 0,
           lastModifiedAppType: 'FRESH',
+          lastModifiedAppId: freshApplicationId,
         }
       });
 
@@ -939,6 +943,9 @@ export class LicensesService {
         renewalApplicationId: true,
         cancelApplicationId: true,
         lastModifiedAppType: true,
+        lastModifiedAppId: true,
+        previousModifiedAppType: true,
+        previousModifiedAppId: true,
         lastModifiedRenewalId: true,
         renewalIds: true,
       },
@@ -1259,6 +1266,9 @@ export class LicensesService {
         renewalApplicationId: true,
         cancelApplicationId: true,
         lastModifiedAppType: true,
+        lastModifiedAppId: true,
+        previousModifiedAppType: true,
+        previousModifiedAppId: true,
         lastModifiedRenewalId: true,
         renewalIds: true,
         licenseNumber: true,
@@ -1364,11 +1374,18 @@ export class LicensesService {
     currentUserId: number,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
-    // Capture the license's current status BEFORE the update so the workflow
-    // history accurately reflects the previous state (fixes hardcoded ACTIVE bug).
+    // Capture the license's current status and tracking fields BEFORE the update
+    // so the workflow history and previous-modified tracking are accurate.
     const currentLicense = await tx.licenses.findUnique({
       where: { id: licenseId },
-      select: { status: true },
+      select: {
+        status: true,
+        lastModifiedAppType: true,
+        lastModifiedAppId: true,
+        lastModifiedRenewalId: true,
+        renewalApplicationId: true,
+        freshApplicationId: true,
+      },
     });
 
     await tx.licenses.update({
@@ -1379,7 +1396,15 @@ export class LicensesService {
         cancellationReason: reason,
         cancellationDate: new Date(),
         cancelApplicationId: applicationId,
+        // Shift current → previous tracking
+        previousModifiedAppType: currentLicense?.lastModifiedAppType,
+        previousModifiedAppId: currentLicense?.lastModifiedAppId ?? (
+          (currentLicense?.lastModifiedAppType || '').toUpperCase() === 'FRESH'
+            ? currentLicense?.freshApplicationId
+            : currentLicense?.lastModifiedRenewalId ?? currentLicense?.renewalApplicationId
+        ),
         lastModifiedAppType: 'CANCELLATION',
+        lastModifiedAppId: applicationId,
       },
     });
 

--- a/backend/src/modules/licenses/licenses.service.ts
+++ b/backend/src/modules/licenses/licenses.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../services/prisma.service';
-import { LicenseStatus } from '@prisma/client';
+import { LicenseStatus, Prisma } from '@prisma/client';
 import * as puppeteer from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -700,7 +700,7 @@ export class LicensesService {
                 </tr>
                 <tr>
                   <th>Valid Till</th>
-                  <td style="color: #c0392b; font-weight: 600;">${validTill.toLocaleDateString('en-IN', { day: '2-digit', month: 'long', year: 'numeric' })}</td>
+                  <td style="color: #c0392b; font-weight: 600;">${validTill ? validTill.toLocaleDateString('en-IN', { day: '2-digit', month: 'long', year: 'numeric' }) : 'N/A'}</td>
                 </tr>
                 <tr>
                   <th>Area of Validity</th>
@@ -1355,5 +1355,38 @@ export class LicensesService {
     }
 
     return null;
+  }
+
+  async cancelLicense(
+    licenseId: number,
+    reason: string,
+    applicationId: number,
+    currentUserId: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.licenses.update({
+      where: { id: licenseId },
+      data: {
+        status: LicenseStatus.CANCELLED,
+        validTill: null,
+        cancellationReason: reason,
+        cancellationDate: new Date(),
+        cancelApplicationId: applicationId,
+        lastModifiedAppType: 'CANCELLATION',
+      },
+    });
+
+    await tx.licenseWorkflowHistory.create({
+      data: {
+        licenseId,
+        action: 'CANCELLED',
+        applicationId,
+        applicationType: 'CANCELLATION',
+        previousStatus: LicenseStatus.ACTIVE,
+        newStatus: LicenseStatus.CANCELLED,
+        changedBy: currentUserId,
+        remarks: `License cancelled. Reason: ${reason}`,
+      },
+    });
   }
 }

--- a/backend/src/modules/renewal/renewal-form.service.ts
+++ b/backend/src/modules/renewal/renewal-form.service.ts
@@ -30,6 +30,13 @@ export class RenewalFormService {
         throw new NotFoundException('License not found. Cannot create renewal without a valid license.');
       }
 
+      // 1a. Check if the license has been CANCELLED
+      if (licenseRecord.status === 'CANCELLED') {
+        throw new BadRequestException(
+          'Cannot create a renewal application for a cancelled license. This license has been permanently cancelled and no further actions are allowed.',
+        );
+      }
+
       const resolvedLicenseId = licenseRecord.id;
       const resolvedLicenseNumber = licenseRecord.licenseNumber;
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -37,7 +37,7 @@ export class SchedulerService {
         to: 'Applicant-Phone', // In real scenario, join with user/application contact info
         type: 'SMS',
         subject: 'License Expiry Warning',
-        message: `Your Arms License ${license.licenseNumber} will expire on ${license.validTill.toDateString()}. Please submit a renewal application.`
+        message: `Your Arms License ${license.licenseNumber} will expire on ${license.validTill?.toDateString() || 'N/A'}. Please submit a renewal application.`
       });
     }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -69,7 +69,7 @@ const nextConfig = {
       fallback: [
         {
           source: '/api/:path*',
-          destination: `${process.env.BACKEND_URL || 'http://localhost:3001'}/api/:path*`,
+          destination: `${process.env.BACKEND_URL || 'http://localhost:3000'}/api/:path*`,
         },
       ],
     };

--- a/frontend/src/app/forms/renewal/page.tsx
+++ b/frontend/src/app/forms/renewal/page.tsx
@@ -10,6 +10,7 @@ import { getDocumentUploadMeta } from '../../../services/fileHandler';
 import { locationAPI } from '../../../api/locationApi';
 import { RenewalService } from '../../../api/renewalService';
 import LicenseService from '../../../services/licenseService';
+import CancelService from '../../../api/cancelService';
 import RenewalHeader from '../../../components/forms/renewal/RenewalHeader';
 import {
   applyPrefilledDocumentUploads,
@@ -2323,6 +2324,32 @@ function RenewalFormPageContent() {
         throw new Error('No license data found for the provided License ID or License Number.');
       }
 
+      // Check if the license has been CANCELLED
+      if (freshData.status === 'CANCELLED') {
+        throw new Error('This license has been cancelled.');
+      }
+
+      // Check if a PENDING cancellation request already exists for this license
+      try {
+        const existingCancelResponse = await CancelService.getCancelRequests({
+          licenseId: Number(freshData.licenseId || freshData.id),
+          status: 'PENDING',
+        });
+        const existingCancelData = existingCancelResponse?.data || [];
+        if (Array.isArray(existingCancelData) && existingCancelData.length > 0) {
+          throw new Error('This license is already in the cancellation process.');
+        }
+      } catch (err: any) {
+        // Re-throw if it's our specific validation error
+        if (
+          err?.message === 'This license is already in the cancellation process.' ||
+          err?.message === 'This license has been cancelled.'
+        ) {
+          throw err;
+        }
+        // Otherwise, if the check fails (network error), allow proceeding (backend will validate)
+      }
+
       const numericLicenseId = String(freshData.licenseId || freshData.id || licenseIdentifier);
       const bioData = freshData.biometricData?.biometricData || freshData.biometricData || null;
       const fingerprints = bioData?.fingerprints || [];
@@ -2430,6 +2457,33 @@ function RenewalFormPageContent() {
       if (!licenseData) {
         throw new Error('No license data found for the provided License ID or License Number.');
       }
+
+      // Check if the license has been CANCELLED
+      if (licenseData.status === 'CANCELLED') {
+        throw new Error('This license has been cancelled.');
+      }
+
+      // Check if a PENDING cancellation request already exists for this license
+      try {
+        const existingCancelResponse = await CancelService.getCancelRequests({
+          licenseId: Number(licenseData.licenseId || licenseData.id),
+          status: 'PENDING',
+        });
+        const existingCancelData = existingCancelResponse?.data || [];
+        if (Array.isArray(existingCancelData) && existingCancelData.length > 0) {
+          throw new Error('This license is already in the cancellation process.');
+        }
+      } catch (err: any) {
+        // Re-throw if it's our specific validation error
+        if (
+          err?.message === 'This license is already in the cancellation process.' ||
+          err?.message === 'This license has been cancelled.'
+        ) {
+          throw err;
+        }
+        // Otherwise, if the check fails (network error), allow proceeding (backend will validate)
+      }
+
       router.push(`/forms/renewal?licenseId=${encodeURIComponent(value)}`);
     } catch (err: any) {
       setVerificationError(err?.message || 'Failed to verify License ID or License Number.');
@@ -2735,6 +2789,13 @@ function RenewalFormPageContent() {
         // Step 1: Fetch license data exactly ONCE.
         const applicationCheckResponse = await ApplicationService.getLicense(resolvedLicenseId);
         const freshData = extractData(applicationCheckResponse);
+
+        // Check if the license has been CANCELLED
+        if (freshData?.status === 'CANCELLED') {
+          toast.error('Cannot create a renewal application for a cancelled license. This license has been permanently cancelled and no further actions are allowed.');
+          setIsLoading(false);
+          return;
+        }
 
         if (!freshData) {
           throw new Error('No license data found for the provided ID.');

--- a/frontend/src/app/licenses/page.tsx
+++ b/frontend/src/app/licenses/page.tsx
@@ -8,6 +8,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
+  Ban,
   Download,
   Eye,
   FileDown,
@@ -85,7 +86,7 @@ const getFullName = (license: LicenseData | null | undefined) =>
   [license?.firstName, license?.middleName, license?.lastName].filter(Boolean).join(' ') || '-';
 
 const getExpiryState = (license: LicenseData) => {
-  if (!license.validTill) return { label: 'Unknown', color: 'bg-gray-100 text-gray-700', dot: 'bg-gray-400' };
+  if (!license.validTill) return { };
   const today = new Date();
   const expiry = new Date(license.validTill);
   const days = Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
@@ -305,58 +306,67 @@ function LicenseManagementContent() {
       <Header showCreateForm showBackButton />
 
       <main className='mt-[64px] md:mt-[70px] p-4 sm:p-6 print:mt-0 print:p-0'>
-        <section className='grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4 print:hidden'>
+        <section className='grid grid-cols-8 gap-1 print:hidden'>
           {[
             {
               label: 'Total Licenses',
               value: stats?.total ?? 0,
               icon: ShieldCheck,
               tab: 'all' as LicenseTab,
+              color: 'text-[#001F54]',
             },
             {
               label: 'Active Licenses',
               value: stats?.active ?? 0,
               icon: CheckCircle2,
               status: 'ACTIVE',
+              color: 'text-green-600',
             },
             {
               label: 'Expiring in 90 Days',
               value: stats?.expiringWithin90Days ?? 0,
               icon: Clock,
               tab: 'expiring' as LicenseTab,
+              color: 'text-orange-500',
             },
             {
               label: 'Expiring in 60 Days',
               value: stats?.expiringWithin60Days ?? 0,
               icon: Clock,
               tab: 'expiring' as LicenseTab,
+              color: 'text-amber-500',
             },
             {
               label: 'Expiring in 30 Days',
               value: stats?.expiringWithin30Days ?? 0,
               icon: AlertTriangle,
               tab: 'expiring' as LicenseTab,
+              color: 'text-red-500',
             },
             {
               label: 'Expired Licenses',
               value: stats?.expired ?? 0,
               icon: XCircle,
               tab: 'expired' as LicenseTab,
+              color: 'text-gray-500',
             },
             {
               label: 'Renewed Licenses',
               value: stats?.renewed ?? 0,
               icon: History,
               tab: 'audit' as LicenseTab,
+              color: 'text-indigo-600',
             },
             {
               label: 'Cancelled Licenses',
               value: stats?.cancelled ?? 0,
               icon: XCircle,
               status: 'CANCELLED',
+              color: 'text-rose-600',
             },
           ].map(card => {
             const Icon = card.icon;
+
             return (
               <button
                 key={card.label}
@@ -366,18 +376,22 @@ function LicenseManagementContent() {
                   setStatusFilter(card.status || '');
                   setPage(1);
                 }}
-                className='rounded-md border border-gray-200 bg-white p-4 text-left shadow-sm transition hover:border-[#001F54]/40'
+                className='group rounded-lg border border-gray-200 border-t-4 border-t-[#001F54] bg-white p-1 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md'
               >
-                <div className='flex items-center justify-between'>
-                  <span className='text-sm font-semibold text-gray-600'>{card.label}</span>
-                  <Icon className='h-5 w-5 text-[#001F54]' />
+                {/* Icon + Label */}
+                <div className='flex items-center gap-2'>
+                  <Icon className={`h-5 w-5 ${card.color}`} />
+                  <span className='text-sm font-medium text-gray-600'>{card.label}</span>
                 </div>
-                <div className='mt-2 text-2xl font-bold text-[#001F54]'>{card.value}</div>
+
+                {/* Centered Value */}
+                <div className='mt-2 flex justify-center'>
+                  <span className='text-3xl font-bold text-[#001F54]'>{card.value}</span>
+                </div>
               </button>
             );
           })}
         </section>
-
         <section className='mt-5 rounded-md border border-gray-200 bg-white shadow-sm'>
           <div className='flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-3 print:hidden'>
             {[
@@ -602,24 +616,56 @@ function LicenseManagementContent() {
                                 >
                                   <Eye className='h-4 w-4' />
                                 </button>
-                                <button
-                                  type='button'
-                                  onClick={() =>
-                                    router.push(`/forms/renewal?licenseId=${license.id}`)
-                                  }
-                                  className='rounded-md bg-[#001F54] px-3 py-2 text-xs font-medium text-white hover:bg-[#012a73]'
-                                >
-                                  Renewal
-                                </button>
-                                <button
-                                  type='button'
-                                  onClick={() =>
-                                    router.push(`/cancelForm/new?licenseId=${license.id}`)
-                                  }
-                                  className='rounded-md bg-red-600 px-3 py-2 text-xs font-medium text-white hover:bg-red-700'
-                                >
-                                  Cancel
-                                </button>
+                                <div className='relative group'>
+                                  <button
+                                    type='button'
+                                    disabled={license.status === 'CANCELLED'}
+                                    onClick={() =>
+                                      router.push(`/forms/renewal?licenseId=${license.id}`)
+                                    }
+                                    className={`rounded-md px-3 py-2 text-xs font-medium transition-colors ${
+                                      license.status === 'CANCELLED'
+                                        ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                                        : 'bg-[#001F54] text-white hover:bg-[#012a73]'
+                                    }`}
+                                  >
+                                    Renewal
+                                  </button>
+                                  {license.status === 'CANCELLED' && (
+                                    <div className='absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-50'>
+                                      <div className='bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-lg whitespace-nowrap'>
+                                        This license has been cancelled. No further actions are
+                                        allowed.
+                                        <div className='absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900' />
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                                <div className='relative group'>
+                                  <button
+                                    type='button'
+                                    disabled={license.status === 'CANCELLED'}
+                                    onClick={() =>
+                                      router.push(`/cancelForm/new?licenseId=${license.id}`)
+                                    }
+                                    className={`rounded-md px-3 py-2 text-xs font-medium transition-colors ${
+                                      license.status === 'CANCELLED'
+                                        ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                                        : 'bg-red-600 text-white hover:bg-red-700'
+                                    }`}
+                                  >
+                                    Cancel
+                                  </button>
+                                  {license.status === 'CANCELLED' && (
+                                    <div className='absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-50'>
+                                      <div className='bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-lg whitespace-nowrap'>
+                                        This license has been cancelled. No further actions are
+                                        allowed.
+                                        <div className='absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900' />
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
                               </div>
                             </td>
                           </tr>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,8 +9,6 @@ import { useNotifications } from '../config/notificationContext';
 import NotificationDropdown from './NotificationDropdown';
 import Link from 'next/link';
 import { APPLICATION_TYPES } from '../config/helpers';
-import { ApplicationService } from '../api/applicationService';
-import { CancelService } from '../api/cancelService';
 import { isLicenseManagementRole } from '@/utils/roleUtils';
 
 interface BreadcrumbItem {
@@ -62,10 +60,6 @@ const Header = (props: HeaderProps) => {
   const { unreadCount } = useNotifications();
   const [showNotifications, setShowNotifications] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
-  const [showCancelModal, setShowCancelModal] = useState(false);
-  const [cancelLicenseId, setCancelLicenseId] = useState('');
-  const [cancelLookupError, setCancelLookupError] = useState<string | null>(null);
-  const [isCancelLookupLoading, setIsCancelLookupLoading] = useState(false);
 
   const router = useRouter();
   const pathname = usePathname();
@@ -87,73 +81,12 @@ const Header = (props: HeaderProps) => {
       } else if (type.key === 'renewal') {
         router.push('/forms/renewal');
       } else if (type.key === 'cancel') {
-        setCancelLicenseId('');
-        setCancelLookupError(null);
-        setShowCancelModal(true);
+        router.push('/cancelForm/new');
       } else {
         router.push(`/inbox?type=all?type=${encodeURIComponent(type.key)}`);
       }
     } else if (onShowMessage) {
       onShowMessage('This feature will come soon', 'info');
-    }
-  };
-
-  const handleCancelSubmit = async () => {
-    const id = cancelLicenseId.trim();
-
-    if (!id) {
-      setCancelLookupError('Enter a License ID or License Number.');
-      return;
-    }
-
-    try {
-      setIsCancelLookupLoading(true);
-      setCancelLookupError(null);
-
-      const response = await ApplicationService.getLicense(id);
-      const freshApplication = response?.data ?? response;
-
-      if (!freshApplication) {
-        throw new Error('No license data returned for that ID or number.');
-      }
-
-      const workflowStatusCode = freshApplication?.workflowStatus?.code?.toString().toUpperCase();
-      const hasApprovedHistory =
-        Array.isArray(freshApplication?.workflowHistories) &&
-        freshApplication.workflowHistories.some(
-          (history: any) => history?.actionTaken?.toString().toUpperCase() === 'APPROVED'
-        );
-
-      if (workflowStatusCode !== 'APPROVED' && !hasApprovedHistory) {
-        throw new Error('Only approved licenses can create a cancellation form.');
-      }
-
-      // Check if a cancellation request already exists for this license
-      try {
-        const resolvedLicenseId = Number(freshApplication.licenseId || freshApplication.id);
-        const existingCancelResponse = await CancelService.getCancelRequests({ licenseId: resolvedLicenseId });
-        const existingCancel = existingCancelResponse?.data || existingCancelResponse;
-        if (Array.isArray(existingCancel) && existingCancel.length > 0) {
-          throw new Error('A cancellation request already exists for this license.');
-        }
-      } catch (err: any) {
-        if (!err.message.includes('already exists')) {
-          // If it's a general network error/not found, ignore it and let user proceed, but if it has matching message, throw.
-        } else {
-          throw err;
-        }
-      }
-
-      setShowCancelModal(false);
-      router.push(
-        `/cancelForm/new?licenseId=${encodeURIComponent(String(freshApplication.licenseId || freshApplication.id))}`
-      );
-    } catch (error: any) {
-      const message = error?.message || 'Unable to fetch fresh application data.';
-      setCancelLookupError(message);
-      onShowMessage?.(message, 'error');
-    } finally {
-      setIsCancelLookupLoading(false);
     }
   };
 
@@ -420,57 +353,6 @@ const Header = (props: HeaderProps) => {
 
 
 
-      {showCancelModal && (
-        <div className='fixed inset-0 z-[60] flex items-center justify-center bg-black/50 px-4'>
-          <div className='w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl'>
-            <h2 className='text-lg font-semibold text-gray-900'>Cancel Application</h2>
-            <p className='mt-2 text-sm text-gray-600'>
-              Enter the approved License ID or License Number to initiate the cancellation request.
-            </p>
-
-            <div className='mt-4'>
-              <label
-                htmlFor='cancel-license-id'
-                className='block text-sm font-medium text-gray-700'
-              >
-                License ID / License Number
-              </label>
-              <input
-                id='cancel-license-id'
-                value={cancelLicenseId}
-                onChange={e => {
-                  setCancelLicenseId(e.target.value);
-                  if (cancelLookupError) setCancelLookupError(null);
-                }}
-                placeholder='Enter License ID or License Number (e.g., LUAN...)'
-                className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-[#001F54] focus:ring-2 focus:ring-[#001F54]/20'
-                autoFocus
-              />
-              {cancelLookupError && (
-                <p className='mt-2 text-sm text-red-600'>{cancelLookupError}</p>
-              )}
-            </div>
-
-            <div className='mt-6 flex justify-end gap-3'>
-              <button
-                type='button'
-                onClick={() => setShowCancelModal(false)}
-                className='rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50'
-              >
-                Cancel
-              </button>
-              <button
-                type='button'
-                onClick={handleCancelSubmit}
-                disabled={isCancelLookupLoading}
-                className='rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-70'
-              >
-                {isCancelLookupLoading ? 'Loading…' : 'Continue'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </header>
   );
 };

--- a/frontend/src/components/cancelForm/CancelRequestDetail.tsx
+++ b/frontend/src/components/cancelForm/CancelRequestDetail.tsx
@@ -113,37 +113,43 @@ export default function CancelRequestDetail({
   //  - it has not already been fetched (prevents duplicate calls on re-renders).
   const licenseFetchedFor = React.useRef<string | null>(null);
 
-  // Source application data: after fetching the license, read `lastModifiedAppType`
-  // and fetch either the renewal application (GET /api/renewal-forms/:id) or the
-  // fresh application (GET /api/application-form?applicationId=:id) accordingly.
+  // Source application data: after fetching the license, read `previousModifiedAppType`
+  // and fetch the corresponding application via its GET API.
+  //
+  // For the Cancellation Original tab, we use `previousModifiedAppType`/`previousModifiedAppId`
+  // (not `lastModifiedAppType`) because:
+  //   - When a cancellation is approved, `lastModifiedAppType` is set to 'CANCELLATION'
+  //     and the source app ID becomes the cancel request ID.
+  //   - The Original tab should show the application that was active BEFORE the cancellation,
+  //     which is stored in `previousModifiedAppType` + `previousModifiedAppId`.
+  //
+  // Supported previous types:
+  //   - previousModifiedAppType === 'RENEWAL' → GET /api/renewal-forms/:previousModifiedAppId
+  //   - previousModifiedAppType === 'FRESH'   → GET /api/application-form?applicationId=:previousModifiedAppId
+  //
+  // The Fresh/Renewal GET API response already includes uploaded documents and
+  // workflow history — no separate API calls are made for those.
   const [sourceAppData, setSourceAppData] = useState<any>(null);
   const [sourceAppLoading, setSourceAppLoading] = useState(false);
   const sourceAppFetchedRef = useRef<string | null>(null);
 
-  // After license data is loaded, use `lastModifiedAppType` from the license
-  // response to fetch the source application:
-  //   - lastModifiedAppType === 'RENEWAL' → GET /api/renewal-forms/:renewalApplicationId
-  //   - lastModifiedAppType === 'FRESH'   → GET /api/application-form?applicationId=:freshApplicationId
-  //
-  // The Fresh/Renewal GET API response already includes uploaded documents and
-  // workflow history — no separate API calls are made for those.
   useEffect(() => {
     if (activeTab !== 'original' || !licenseData) return;
 
-    const lastModifiedAppType = (licenseData as any).lastModifiedAppType;
-    const renewalAppId = (licenseData as any).renewalApplicationId;
-    const freshAppId = (licenseData as any).freshApplicationId;
+    const prevAppType = (licenseData as any).previousModifiedAppType;
+    const prevAppId = (licenseData as any).previousModifiedAppId;
 
-    if (!lastModifiedAppType) return;
+    if (!prevAppType || !prevAppId) return;
 
-    // Determine source app ID and fetch it if not already fetched
-    if (lastModifiedAppType === 'RENEWAL' && renewalAppId) {
-      const key = `renewal-${renewalAppId}`;
+    const normalizedType = String(prevAppType).trim().toUpperCase();
+
+    if (normalizedType === 'RENEWAL') {
+      const key = `renewal-${prevAppId}`;
       if (sourceAppFetchedRef.current !== key) {
         sourceAppFetchedRef.current = key;
-        setSourceAppData(null); // Clear any stale data
+        setSourceAppData(null);
         setSourceAppLoading(true);
-        apiClient.get<any>(`/renewal-forms/${renewalAppId}`)
+        apiClient.get<any>(`/renewal-forms/${prevAppId}`)
           .then((res: any) => {
             const data = res?.data ?? res;
             if (data) setSourceAppData(data);
@@ -151,13 +157,13 @@ export default function CancelRequestDetail({
           .catch((err: any) => console.error('Failed to fetch renewal application:', err))
           .finally(() => setSourceAppLoading(false));
       }
-    } else if (lastModifiedAppType === 'FRESH' && freshAppId) {
-      const key = `fresh-${freshAppId}`;
+    } else if (normalizedType === 'FRESH') {
+      const key = `fresh-${prevAppId}`;
       if (sourceAppFetchedRef.current !== key) {
         sourceAppFetchedRef.current = key;
-        setSourceAppData(null); // Clear any stale data
+        setSourceAppData(null);
         setSourceAppLoading(true);
-        apiClient.get<any>(`/application-form?applicationId=${freshAppId}`)
+        apiClient.get<any>(`/application-form?applicationId=${prevAppId}`)
           .then((res: any) => {
             const data = res?.data ?? res;
             if (data) setSourceAppData(data);
@@ -382,7 +388,7 @@ export default function CancelRequestDetail({
           <>
             <OriginalLicenseDetails
               sourceAppData={sourceAppData}
-              sourceAppType={licenseData?.lastModifiedAppType}
+              sourceAppType={licenseData?.previousModifiedAppType}
               licenseData={licenseData}
               licenseId={request.licenseId}
               licenseNumber={request.Licenses?.licenseNumber || request.licenseNumber}
@@ -398,8 +404,8 @@ export default function CancelRequestDetail({
  * Mirrors the Renewal Application Details page Original tab layout exactly.
  *
  * Uses the source application data (renewal or fresh application fetched based on
- * lastModifiedAppType from the License GET API response) to display the latest
- * approved application details.
+ * previousModifiedAppType from the License GET API response) to display the
+ * application that existed before the cancellation was approved.
  *
  * The licenseData is still used for license-specific info (number, status).
  */

--- a/frontend/src/components/cancelForm/CancelRequestDetail.tsx
+++ b/frontend/src/components/cancelForm/CancelRequestDetail.tsx
@@ -52,7 +52,6 @@ import { ApplicationService } from '@/api/applicationService';
 import RenewalApplicationDetailsHeader from '@/components/renewal/renewalapplicationdetailsheader';
 import { getStatusStyle } from '@/utils/statusColors';
 import { RichTextDisplay } from '@/components/RichTextDisplay';
-import { getDocuments } from '@/services/documentService';
 import { apiClient } from '@/config/authenticatedApiClient';
 import { LazySection } from '@/components/LazySection';
 import { formatGender } from '@/utils/formatters';
@@ -104,77 +103,68 @@ export default function CancelRequestDetail({
   const [licenseLoading, setLicenseLoading] = useState(false);
   const [licenseError, setLicenseError] = useState<string | null>(null);
 
-  // Original License Documents & Workflow History — same pattern as Renewal.
-  const [originDocuments, setOriginDocuments] = useState<any[]>([]);
-  const [originDocumentsLoading, setOriginDocumentsLoading] = useState(false);
-  const [originalLicenseHistory, setOriginalLicenseHistory] = useState<any[]>([]);
-  const [originalLicenseHistoryLoading, setOriginalLicenseHistoryLoading] = useState(false);
-  const originalDocumentsFetchedRef = useRef<string | number | null>(null);
-  const originalHistoryFetchedRef = useRef<string | number | null>(null);
+  // Original License Documents & Workflow History — derived from sourceAppData.
+  // The Fresh/Renewal GET APIs already return uploaded documents and workflow history,
+  // so no separate /documents or /workflow/history API calls are made.
 
   // Lazily fetch the License GET API (GET /api/licenses/:licenseId) ONLY when:
   //  - the Original License Details tab is opened (loadOriginal), and
   //  - we have a licenseId from the Cancellation GET API response, and
   //  - it has not already been fetched (prevents duplicate calls on re-renders).
-  // No Fresh Application API is used here.
   const licenseFetchedFor = React.useRef<string | null>(null);
 
-  // After license data is loaded, fetch the workflow history and documents
-  // for the original source application — matching the Renewal pattern:
-  //   - Use licenseData.id as the source application ID
-  //   - Derive the application type from licenseData.acknowledgementNo first char:
-  //       'F' → FRESH / Fresh  |  'R' → RENEWAL / Renewal  |  'C' → CANCELLATION / Cancellation
+  // Source application data: after fetching the license, read `lastModifiedAppType`
+  // and fetch either the renewal application (GET /api/renewal-forms/:id) or the
+  // fresh application (GET /api/application-form?applicationId=:id) accordingly.
+  const [sourceAppData, setSourceAppData] = useState<any>(null);
+  const [sourceAppLoading, setSourceAppLoading] = useState(false);
+  const sourceAppFetchedRef = useRef<string | null>(null);
+
+  // After license data is loaded, use `lastModifiedAppType` from the license
+  // response to fetch the source application:
+  //   - lastModifiedAppType === 'RENEWAL' → GET /api/renewal-forms/:renewalApplicationId
+  //   - lastModifiedAppType === 'FRESH'   → GET /api/application-form?applicationId=:freshApplicationId
+  //
+  // The Fresh/Renewal GET API response already includes uploaded documents and
+  // workflow history — no separate API calls are made for those.
   useEffect(() => {
     if (activeTab !== 'original' || !licenseData) return;
 
-    const srcAppId = (licenseData as any).id;
-    const ackNo = (licenseData as any).acknowledgementNo;
-    if (!srcAppId || !ackNo) return;
+    const lastModifiedAppType = (licenseData as any).lastModifiedAppType;
+    const renewalAppId = (licenseData as any).renewalApplicationId;
+    const freshAppId = (licenseData as any).freshApplicationId;
 
-    // Derive type from the first character of acknowledgement number.
-    const firstChar = String(ackNo).charAt(0).toUpperCase();
-    let derivedType: string;
-    if (firstChar === 'R') derivedType = 'RENEWAL';
-    else if (firstChar === 'C') derivedType = 'CANCELLATION';
-    else derivedType = 'FRESH';
+    if (!lastModifiedAppType) return;
 
-    let docDerivedType: string;
-    if (firstChar === 'R') docDerivedType = 'Renewal';
-    else if (firstChar === 'C') docDerivedType = 'Cancellation';
-    else docDerivedType = 'Fresh';
-
-    // --- Fetch Workflow History (once per source app) ---
-    if (String(srcAppId) !== String(originalHistoryFetchedRef.current)) {
-      originalHistoryFetchedRef.current = srcAppId;
-      setOriginalLicenseHistoryLoading(true);
-
-      apiClient.get<any>(`/workflow/history/${srcAppId}?type=${derivedType}`)
-        .then((historyResponse: any) => {
-          if (historyResponse && historyResponse.success) {
-            setOriginalLicenseHistory(historyResponse.data);
-          } else if (Array.isArray(historyResponse)) {
-            setOriginalLicenseHistory(historyResponse);
-          }
-        })
-        .catch((historyErr: any) => {
-          console.error('Failed to fetch original license workflow history', historyErr);
-          setOriginalLicenseHistory([]);
-        })
-        .finally(() => setOriginalLicenseHistoryLoading(false));
-    }
-
-    // --- Fetch Documents (once per source app) ---
-    if (String(srcAppId) !== String(originalDocumentsFetchedRef.current)) {
-      originalDocumentsFetchedRef.current = srcAppId;
-      setOriginDocumentsLoading(true);
-
-      getDocuments(Number(srcAppId), docDerivedType)
-        .then((docs: any[]) => setOriginDocuments(docs))
-        .catch((docsErr: any) => {
-          console.error('Failed to fetch origin documents:', docsErr);
-          setOriginDocuments([]);
-        })
-        .finally(() => setOriginDocumentsLoading(false));
+    // Determine source app ID and fetch it if not already fetched
+    if (lastModifiedAppType === 'RENEWAL' && renewalAppId) {
+      const key = `renewal-${renewalAppId}`;
+      if (sourceAppFetchedRef.current !== key) {
+        sourceAppFetchedRef.current = key;
+        setSourceAppData(null); // Clear any stale data
+        setSourceAppLoading(true);
+        apiClient.get<any>(`/renewal-forms/${renewalAppId}`)
+          .then((res: any) => {
+            const data = res?.data ?? res;
+            if (data) setSourceAppData(data);
+          })
+          .catch((err: any) => console.error('Failed to fetch renewal application:', err))
+          .finally(() => setSourceAppLoading(false));
+      }
+    } else if (lastModifiedAppType === 'FRESH' && freshAppId) {
+      const key = `fresh-${freshAppId}`;
+      if (sourceAppFetchedRef.current !== key) {
+        sourceAppFetchedRef.current = key;
+        setSourceAppData(null); // Clear any stale data
+        setSourceAppLoading(true);
+        apiClient.get<any>(`/application-form?applicationId=${freshAppId}`)
+          .then((res: any) => {
+            const data = res?.data ?? res;
+            if (data) setSourceAppData(data);
+          })
+          .catch((err: any) => console.error('Failed to fetch fresh application:', err))
+          .finally(() => setSourceAppLoading(false));
+      }
     }
   }, [activeTab, licenseData]);
   useEffect(() => {
@@ -213,7 +203,7 @@ export default function CancelRequestDetail({
     .filter(Boolean)
     .join(' ') || request.applicantName || 'N/A';
 
-  if (licenseLoading) {
+  if (licenseLoading || sourceAppLoading) {
     return (
       <div className='p-6 lg:p-8 bg-slate-50/30 transition-opacity duration-300 animate-pulse rounded-3xl bg-white border border-slate-200'>
         {/* Application Information Section Skeleton */}
@@ -269,7 +259,7 @@ export default function CancelRequestDetail({
         <div className='flex flex-col items-center justify-center py-8 text-center'>
           <div className='w-10 h-10 border-4 border-blue-100 border-t-blue-600 rounded-full animate-spin mb-4'></div>
           <p className='text-sm font-medium text-slate-500'>
-            Loading original license details...
+            Loading original application details...
           </p>
         </div>
       </div>
@@ -391,13 +381,11 @@ export default function CancelRequestDetail({
         {activeTab === 'original' && (
           <>
             <OriginalLicenseDetails
+              sourceAppData={sourceAppData}
+              sourceAppType={licenseData?.lastModifiedAppType}
               licenseData={licenseData}
               licenseId={request.licenseId}
               licenseNumber={request.Licenses?.licenseNumber || request.licenseNumber}
-              originDocuments={originDocuments}
-              originDocumentsLoading={originDocumentsLoading}
-              originalLicenseHistory={originalLicenseHistory}
-              originalLicenseHistoryLoading={originalLicenseHistoryLoading}
             />
           </>
         )}
@@ -408,43 +396,61 @@ export default function CancelRequestDetail({
 /**
  * Original License Details tab content.
  * Mirrors the Renewal Application Details page Original tab layout exactly.
- * Uses data from the License GET API (GET /api/licenses/:licenseId) and
- * fetches documents + workflow history via separate APIs.
+ *
+ * Uses the source application data (renewal or fresh application fetched based on
+ * lastModifiedAppType from the License GET API response) to display the latest
+ * approved application details.
+ *
+ * The licenseData is still used for license-specific info (number, status).
  */
 function OriginalLicenseDetails({
+  sourceAppData,
+  sourceAppType,
   licenseData,
   licenseId,
   licenseNumber,
-  originDocuments,
-  originDocumentsLoading,
-  originalLicenseHistory,
-  originalLicenseHistoryLoading,
 }: {
+  sourceAppData: any;
+  sourceAppType?: string;
   licenseData: any;
   licenseId?: number | string | null;
   licenseNumber?: string | null;
-  originDocuments?: any[];
-  originDocumentsLoading?: boolean;
-  originalLicenseHistory?: any[];
-  originalLicenseHistoryLoading?: boolean;
 }) {
   const [expandedHistory, setExpandedHistory] = useState<Record<number, boolean>>({});
 
-  const license = licenseData || {};
-  const applicantName = [license.firstName, license.middleName, license.lastName]
+  // Use source application data (renewal or fresh application) as the primary data source.
+  // Fall back to licenseData for backward compatibility.
+  const app = sourceAppData || licenseData || {};
+
+  // Documents and workflow history are derived directly from the Fresh/Renewal GET API
+  // response — no separate API calls are needed.
+  // The Fresh API returns fileUploads[] and workflowHistories[];
+  // the Renewal API returns similar document/workflow fields at the top level.
+  const originDocuments: any[] = app.fileUploads || app.documents || [];
+  const originDocumentsLoading = false;
+  const originalLicenseHistory: any[] = app.workflowHistories || app.FreshLicenseApplicationsFormWorkflowHistories || [];
+  const originalLicenseHistoryLoading = false;
+  const applicantName = [app.firstName, app.middleName, app.lastName]
     .filter(Boolean)
     .join(' ') || 'N/A';
 
-  // Extract nested data from the License API response to match the Renewal page pattern.
-  // The License API returns licenseDetails, licenseHistories, and criminalHistories as
-  // nested arrays at the top level of the response object (via buildLicenseDetailResponse).
-  const licenseDetail = license.licenseDetails?.[0] || {};
-  const licenseHistory = license.licenseHistories?.[0] || {};
-  const criminalHistory = license.criminalHistories?.[0] || {};
+  // Extract nested data from the source application response.
+  // Both fresh and renewal application APIs return data in the same nested structure
+  // (personal details at top level, addresses, licenseDetails[], licenseHistories[], etc.)
+  const licenseDetail = app.licenseDetails?.[0] || {};
+  const licenseHistory = app.licenseHistories?.[0] || {};
+  const criminalHistory = app.criminalHistories?.[0] || {};
 
   const weapons = Array.isArray(licenseDetail.requestedWeapons)
     ? licenseDetail.requestedWeapons.map((w: any) => w.name || w).join(', ')
     : '';
+
+  // Application type label
+  const appTypeLabel = sourceAppType
+    ? String(sourceAppType).charAt(0).toUpperCase() + String(sourceAppType).slice(1).toLowerCase()
+    : app?.applicationType
+      ? String(app.applicationType).charAt(0).toUpperCase() + String(app.applicationType).slice(1).toLowerCase()
+      : 'Original';
 
   return (
     <div className='space-y-8 bg-slate-50/30 rounded-3xl'>
@@ -456,7 +462,7 @@ function OriginalLicenseDetails({
               <UserRound className='w-5 h-5' />
             </div>
             <h3 className='font-bold text-slate-800 text-lg tracking-tight'>
-              Application Information
+              Application Information — {appTypeLabel}
             </h3>
           </div>
         </div>
@@ -470,31 +476,31 @@ function OriginalLicenseDetails({
               icon={UserRound}
               className='md:col-span-2'
             />
-            {license?.parentOrSpouseName && (
+            {app?.parentOrSpouseName && (
               <DetailItem
                 label='Parent / Spouse Name'
-                value={license.parentOrSpouseName}
+                value={app.parentOrSpouseName}
                 icon={Users}
               />
             )}
-            {license?.sex && (
-              <DetailItem label='Gender' value={formatGender(license.sex)} icon={UserCheck} />
+            {app?.sex && (
+              <DetailItem label='Gender' value={formatGender(app.sex)} icon={UserCheck} />
             )}
-            {license?.placeOfBirth && (
-              <DetailItem label='Place of Birth' value={license.placeOfBirth} icon={MapPin} />
+            {app?.placeOfBirth && (
+              <DetailItem label='Place of Birth' value={app.placeOfBirth} icon={MapPin} />
             )}
-            {(license?.dateOfBirth || license?.dob) && (
+            {(app?.dateOfBirth || app?.dob) && (
               <DetailItem
                 label='Date of Birth'
                 value={
-                  license?.dateOfBirth
-                    ? new Date(license.dateOfBirth).toLocaleDateString('en-IN', {
+                  app?.dateOfBirth
+                    ? new Date(app.dateOfBirth).toLocaleDateString('en-IN', {
                         year: 'numeric',
                         month: 'long',
                         day: 'numeric',
                       })
-                    : license?.dob
-                      ? new Date(license.dob).toLocaleDateString('en-IN', {
+                    : app?.dob
+                      ? new Date(app.dob).toLocaleDateString('en-IN', {
                           year: 'numeric',
                           month: 'long',
                           day: 'numeric',
@@ -504,36 +510,36 @@ function OriginalLicenseDetails({
                 icon={CalendarDays}
               />
             )}
-            {license?.panNumber && (
-              <DetailItem label='PAN Number' value={license.panNumber} icon={CreditCard} mono />
+            {app?.panNumber && (
+              <DetailItem label='PAN Number' value={app.panNumber} icon={CreditCard} mono />
             )}
-            {license?.aadharNumber && (
+            {app?.aadharNumber && (
               <DetailItem
                 label='Aadhar Number'
-                value={license.aadharNumber}
+                value={app.aadharNumber}
                 icon={Fingerprint}
                 mono
               />
             )}
-            {license?.acknowledgementNo && (
+            {app?.acknowledgementNo && (
               <DetailItem
                 label='Acknowledgement Number'
-                value={license.acknowledgementNo}
+                value={app.acknowledgementNo}
                 icon={FileCheck}
                 mono
               />
             )}
-            {license?.currentUser && (
+            {app?.currentUser && (
               <DetailItem
                 label='Current User'
-                value={license.currentUser.username}
+                value={app.currentUser.username}
                 icon={UserCog}
               />
             )}
-            {license?.workflowStatus && (
+            {app?.workflowStatus && (
               <DetailItem
                 label='Workflow Status'
-                value={<StatusBadge status={license.workflowStatus} />}
+                value={<StatusBadge status={app.workflowStatus} />}
                 icon={BadgeCheck}
               />
             )}
@@ -541,21 +547,16 @@ function OriginalLicenseDetails({
               label='Application Type'
               value={
                 <StatusBadge
-                  status={license?.applicationType || 'N/A'}
-                  label={
-                    license?.applicationType
-                      ? String(license.applicationType).charAt(0).toUpperCase() +
-                        String(license.applicationType).slice(1).toLowerCase()
-                      : 'N/A'
-                  }
+                  status={app?.applicationType || appTypeLabel}
+                  label={appTypeLabel}
                 />
               }
               icon={Clock3}
             />
-            {license?.applicationDate && (
+            {app?.applicationDate && (
               <DetailItem
                 label='Date & Time of Submission'
-                value={new Date(license.applicationDate).toLocaleString('en-IN', {
+                value={new Date(app.applicationDate).toLocaleString('en-IN', {
                   year: 'numeric',
                   month: 'short',
                   day: 'numeric',
@@ -572,7 +573,7 @@ function OriginalLicenseDetails({
           <div>
             <SummaryCard
               application={
-                originDocuments?.length ? { ...license, documents: originDocuments } : license
+                originDocuments?.length ? { ...app, documents: originDocuments } : app
               }
               applicationId={String(licenseId ?? '')}
               applicantName={applicantName}
@@ -582,7 +583,7 @@ function OriginalLicenseDetails({
               <div className='relative z-10'>
                 <LazySection minHeight='400px'>
                   <EnhancedApplicationTimeline
-                    application={license}
+                    application={app}
                     workflowHistory={originalLicenseHistory || []}
                   />
                 </LazySection>
@@ -788,7 +789,7 @@ function OriginalLicenseDetails({
       {/* ================= 3. Three-Column Address Row ================= */}
       <div className='grid grid-cols-1 lg:grid-cols-3 gap-8'>
         {(() => {
-          const present = license.presentAddress || {};
+          const present = app.presentAddress || {};
           const presentState =
             typeof present.state === 'object' ? present.state?.name : present.state;
           const presentDistrict =
@@ -820,7 +821,7 @@ function OriginalLicenseDetails({
           );
         })()}
         {(() => {
-          const permanent = license.permanentAddress || {};
+          const permanent = app.permanentAddress || {};
           const permanentState =
             typeof permanent.state === 'object' ? permanent.state?.name : permanent.state;
           const permanentDistrict =
@@ -852,7 +853,7 @@ function OriginalLicenseDetails({
           );
         })()}
         {(() => {
-          const occ = license.occupationAndBusiness || {};
+          const occ = app.occupationAndBusiness || {};
           return (
             <SectionCard
               title='Occupation & Business Details'
@@ -906,7 +907,7 @@ function OriginalLicenseDetails({
         </div>
 
         {(() => {
-          const historyToShow = originalLicenseHistory || license.workflowHistories || [];
+          const historyToShow = originalLicenseHistory || app.workflowHistories || [];
           if (!historyToShow || historyToShow.length === 0) {
             if (originalLicenseHistoryLoading) {
               return (

--- a/frontend/src/components/cancelForm/CancelRequestModal.tsx
+++ b/frontend/src/components/cancelForm/CancelRequestModal.tsx
@@ -180,6 +180,19 @@ export default function CancelRequestModal({
         throw new Error('No license data found for the provided License ID or License Number.');
       }
 
+      // Check if the license has been CANCELLED
+      if (freshData.status === 'CANCELLED') {
+        // Use a sentinel value to indicate cancelled-license state in the FAILED UI path.
+        // The id of -1 prevents any accidental routing matches.
+        setExistingCancel({ id: -1, status: 'APPROVED' });
+        setVerificationStatus('FAILED');
+        setVerificationError(
+          'This license has been permanently cancelled. No further cancellation requests can be raised for this license.',
+        );
+        setVerificationChecking(false);
+        return;
+      }
+
       const numericLicenseId = String(freshData.licenseId || freshData.id || licenseIdentifier);
       const bioData = freshData.biometricData?.biometricData || freshData.biometricData || null;
       const fingerprints = bioData?.fingerprints || [];

--- a/frontend/src/components/cancelForm/SubmitCancelForm.tsx
+++ b/frontend/src/components/cancelForm/SubmitCancelForm.tsx
@@ -95,6 +95,35 @@ export default function SubmitCancelForm() {
         throw new Error('No license data found for the provided License ID or License Number.');
       }
 
+      // Check if the license has been CANCELLED
+      if (freshData.status === 'CANCELLED') {
+        setVerificationError(
+          'This license has already been cancelled.',
+        );
+        setVerificationStatus('FAILED');
+        setVerificationChecking(false);
+        return;
+      }
+
+      // Check if a cancellation request already exists in PENDING state
+      try {
+        const pendingResponse = await CancelService.getCancelRequests({
+          licenseId: Number(freshData.licenseId || freshData.id || licenseIdentifier),
+          status: 'PENDING',
+        });
+        const pendingData = pendingResponse?.data || [];
+        if (Array.isArray(pendingData) && pendingData.length > 0) {
+          setVerificationError(
+            'A cancellation request for this license already exists and is pending approval.',
+          );
+          setVerificationStatus('FAILED');
+          setVerificationChecking(false);
+          return;
+        }
+      } catch {
+        // If the check fails, continue anyway (backend will validate)
+      }
+
       const numericLicenseId = String(freshData.licenseId || freshData.id || licenseIdentifier);
       const bioData = freshData.biometricData?.biometricData || freshData.biometricData || null;
       const fingerprints = bioData?.fingerprints || [];
@@ -411,6 +440,33 @@ export default function SubmitCancelForm() {
             </div>
           </div>
         )}
+      </div>
+    );
+  }
+
+  if (verificationStatus === 'FAILED') {
+    return (
+      <div className='max-w-2xl mx-auto w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8'>
+        <div className='text-center'>
+          <div className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 mb-4'>
+            <svg className='w-8 h-8 text-red-600' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
+            </svg>
+          </div>
+          <h2 className='text-xl font-bold text-gray-900 mb-2'>Cancellation Not Allowed</h2>
+          <p className='text-red-600 font-medium'>{verificationError || 'This license has already been cancelled.'}</p>
+          <button
+            type='button'
+            onClick={() => {
+              setVerificationStatus('ENTER_APP_ID');
+              setVerificationError(null);
+              setFormData(prev => ({ ...prev, licenseId: '' }));
+            }}
+            className='mt-6 px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-medium transition-colors'
+          >
+            Try Another License
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/config/authenticatedApiClient.ts
+++ b/frontend/src/config/authenticatedApiClient.ts
@@ -113,20 +113,16 @@ export class ApiClient {
     // If endpoint is absolute, use it directly
     if (endpoint.startsWith('http')) return endpoint;
 
-    // Normalize base and endpoint to avoid double slashes or duplicated '/api'
-    const base = this.baseUrl.replace(/\/$/, '');
-
-    // If both base and endpoint include the '/api' prefix (e.g. base endsWith '/api' and endpoint startsWith '/api')
-    // then strip the leading '/api' from the endpoint so we don't end up with '/api/api/...'
-    if (base.endsWith('/api') && endpoint.startsWith('/api')) {
-      return `${base}${endpoint.slice(4)}`; // remove the leading '/api' from endpoint
+    // axiosInstance already has baseURL set to NEXT_PUBLIC_API_URL or '/api'.
+    // We just return the endpoint, stripping a leading '/api' if a caller included it
+    // so we don't accidentally send a request to '/api/api/...'.
+    if (endpoint.startsWith('/api/')) {
+      return endpoint.slice(4); // '/api/foo' -> '/foo'
+    } else if (endpoint === '/api') {
+      return '/';
     }
 
-    // If endpoint begins with a '/', just concatenate (base already has no trailing slash)
-    if (endpoint.startsWith('/')) return `${base}${endpoint}`;
-
-    // Otherwise insert a slash between base and endpoint
-    return `${base}/${endpoint}`;
+    return endpoint;
   }
 
   async get<T>(endpoint: string, params?: Record<string, any>): Promise<T> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -686,6 +686,9 @@ export interface LicenseData {
   renewalApplicationId?: number | null;
   cancelApplicationId?: number | null;
   lastModifiedAppType?: string | null;
+  lastModifiedAppId?: number | null;
+  previousModifiedAppType?: string | null;
+  previousModifiedAppId?: number | null;
   lastModifiedRenewalId?: number | null;
   renewalIds?: number[];
 


### PR DESCRIPTION
Short Summary
Made Licenses.validTill nullable to support cancelled licenses.
Added backend validations to block renewals/cancellations for cancelled licenses and prevent duplicate pending cancellation requests.
Refactored the cancellation approval flow to update only required license fields while preserving applicant/license data.
Added status filtering to Cancel Request APIs.
Updated the Renewal form to block renewals for cancelled or pending-cancellation licenses.
Redesigned the License Management dashboard and disabled Renewal/Cancel actions for cancelled licenses with tooltips.
Removed the header cancellation modal and redirected users to /cancelForm/new.
Added frontend validations and "Cancellation Not Allowed" UI.
Fixed API endpoint URL handling and updated frontend backend URL configuration.
Enhanced the License API with previousModifiedAppType and previousModifiedAppId.
Updated the Cancellation Details → Original tab to load the correct Fresh or Renewal application using the previous application reference.