### PR TITLE
Fix UI

### DIFF
--- a/backend/src/modules/licenses/licenses.service.ts
+++ b/backend/src/modules/licenses/licenses.service.ts
@@ -102,7 +102,7 @@ export class LicensesService {
           district: true,
         },
       },
-      //   biometricData: true,
+      biometricData: true,
       criminalHistories: true,
       licenseHistories: true,
       licenseDetails: {
@@ -110,7 +110,7 @@ export class LicensesService {
           requestedWeapons: true,
         },
       },
-      //   fileUploads: true,
+      fileUploads: true,
     };
   }
 

--- a/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
+++ b/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
@@ -260,7 +260,12 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   // the same origin-tab override used by the on-screen Documents table.
   const printApplication = useMemo(() => {
     if (!currentDisplayApp) return null;
-    if (isRenewalView && activeTab === 'original' && originDocuments && originDocuments.length > 0) {
+    if (
+      isRenewalView &&
+      activeTab === 'original' &&
+      originDocuments &&
+      originDocuments.length > 0
+    ) {
       return { ...currentDisplayApp, documents: originDocuments };
     }
     return currentDisplayApp;
@@ -403,42 +408,42 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
           setOriginalLicenseHistory([]);
           return;
         }
-        setOriginalLicenseData(license);          // Now call the Workflow History API using the source application data
-          // from the License API response, matching the Documents API logic:
-          //   - id: the source application's primary key (license.id from the License API)
-          //   - type: derived from the first character of the acknowledgement number:
-          //       'F' → FRESH | 'R' → RENEWAL | 'C' → CANCELLATION
-          if (String(licenseId) !== String(originalLicenseHistoryLoadedIdRef.current)) {
-            originalLicenseHistoryLoadedIdRef.current = licenseId;
-            setOriginalLicenseHistory([]);
+        setOriginalLicenseData(license); // Now call the Workflow History API using the source application data
+        // from the License API response, matching the Documents API logic:
+        //   - id: the source application's primary key (license.id from the License API)
+        //   - type: derived from the first character of the acknowledgement number:
+        //       'F' → FRESH | 'R' → RENEWAL | 'C' → CANCELLATION
+        if (String(licenseId) !== String(originalLicenseHistoryLoadedIdRef.current)) {
+          originalLicenseHistoryLoadedIdRef.current = licenseId;
+          setOriginalLicenseHistory([]);
 
-            // Source application ID from the License API response
-            const srcAppId = (license as any).id;
-            const ackNo = (license as any).acknowledgementNo;
+          // Source application ID from the License API response
+          const srcAppId = (license as any).id;
+          const ackNo = (license as any).acknowledgementNo;
 
-            if (srcAppId && ackNo) {
-              // Derive the type from the first character of the acknowledgement number
-              const firstChar = String(ackNo).charAt(0).toUpperCase();
-              let derivedType: string;
-              if (firstChar === 'R') derivedType = 'RENEWAL';
-              else if (firstChar === 'C') derivedType = 'CANCELLATION';
-              else derivedType = 'FRESH';
+          if (srcAppId && ackNo) {
+            // Derive the type from the first character of the acknowledgement number
+            const firstChar = String(ackNo).charAt(0).toUpperCase();
+            let derivedType: string;
+            if (firstChar === 'R') derivedType = 'RENEWAL';
+            else if (firstChar === 'C') derivedType = 'CANCELLATION';
+            else derivedType = 'FRESH';
 
-              try {
-                const historyResponse = await apiClient.get<any>(
-                  `/workflow/history/${srcAppId}?type=${derivedType}`
-                );
-                if (historyResponse && historyResponse.success) {
-                  setOriginalLicenseHistory(historyResponse.data);
-                } else if (Array.isArray(historyResponse)) {
-                  setOriginalLicenseHistory(historyResponse);
-                }
-              } catch (historyErr) {
-                console.error('Failed to fetch original license workflow history', historyErr);
-                setOriginalLicenseHistory([]);
+            try {
+              const historyResponse = await apiClient.get<any>(
+                `/workflow/history/${srcAppId}?type=${derivedType}`
+              );
+              if (historyResponse && historyResponse.success) {
+                setOriginalLicenseHistory(historyResponse.data);
+              } else if (Array.isArray(historyResponse)) {
+                setOriginalLicenseHistory(historyResponse);
               }
+            } catch (historyErr) {
+              console.error('Failed to fetch original license workflow history', historyErr);
+              setOriginalLicenseHistory([]);
             }
           }
+        }
       } catch (err) {
         console.error('Failed to fetch original license on tab change', err);
       } finally {
@@ -494,7 +499,7 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
     fetchOriginDocuments();
   }, [activeTab, originalLicenseData]);
 
-// Clear success message after 5 seconds
+  // Clear success message after 5 seconds
   useEffect(() => {
     if (successMessage) {
       const timer = setTimeout(() => {
@@ -2078,25 +2083,47 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                                 : null;
                             const applicationUserId = Number(displayApp?.currentUser?.id) || null;
                             // Check for final/closed status first — if final, show only a status message
-                            const finalStatuses = ['APPROVED', 'REJECTED', 'CANCELLED', 'DISPOSED', 'EXPIRED'];
-                            const rawStatusCode = displayApp?.workflowStatus?.code || displayApp?.status || '';
+                            const finalStatuses = [
+                              'APPROVED',
+                              'REJECTED',
+                              'CANCELLED',
+                              'DISPOSED',
+                              'EXPIRED',
+                            ];
+                            const rawStatusCode =
+                              displayApp?.workflowStatus?.code || displayApp?.status || '';
                             const rawStatusName = displayApp?.workflowStatus?.name || rawStatusCode;
-                            const isFinalStatus = finalStatuses.some(s => 
-                              String(rawStatusCode).toUpperCase() === s || 
-                              String(rawStatusName).toUpperCase() === s
+                            const isFinalStatus = finalStatuses.some(
+                              s =>
+                                String(rawStatusCode).toUpperCase() === s ||
+                                String(rawStatusName).toUpperCase() === s
                             );
                             if (isFinalStatus) {
-                              const displayStatus = String(rawStatusName).charAt(0).toUpperCase() + String(rawStatusName).slice(1).toLowerCase();
+                              const displayStatus =
+                                String(rawStatusName).charAt(0).toUpperCase() +
+                                String(rawStatusName).slice(1).toLowerCase();
                               return (
                                 <div className='bg-amber-50 border-2 border-amber-400 rounded-xl p-4 flex items-start gap-3 shadow-sm'>
                                   <div className='p-1.5 rounded-full bg-amber-100 text-amber-600 flex-shrink-0'>
-                                    <svg className='w-5 h-5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z' />
+                                    <svg
+                                      className='w-5 h-5'
+                                      fill='none'
+                                      stroke='currentColor'
+                                      viewBox='0 0 24 24'
+                                    >
+                                      <path
+                                        strokeLinecap='round'
+                                        strokeLinejoin='round'
+                                        strokeWidth={2}
+                                        d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+                                      />
                                     </svg>
                                   </div>
                                   <div>
                                     <p className='text-sm font-semibold text-amber-900'>
-                                      Your application has been <span className='uppercase font-bold'>{displayStatus}</span>. No further processing is allowed.
+                                      Your application has been{' '}
+                                      <span className='uppercase font-bold'>{displayStatus}</span>.
+                                      No further processing is allowed.
                                     </p>
                                   </div>
                                 </div>

--- a/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
+++ b/frontend/src/app/application/[id]/ApplicationDetailClient.tsx
@@ -169,6 +169,9 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
   const [originDocuments, setOriginDocuments] = useState<any[]>([]);
   const [originDocumentsLoading, setOriginDocumentsLoading] = useState(false);
   const printRef = useRef<HTMLDivElement>(null);
+  // Becomes false while the hidden print layout's document/PDF previews are still
+  // rendering, so the Print buttons don't fire window.print() on blank thumbnails.
+  const [printReady, setPrintReady] = useState(true);
   const [dividerPosition, setDividerPosition] = useState(66.66); // Left section percentage (2 of 3 columns)
   const [isDragging, setIsDragging] = useState(false);
   const dividerRef = useRef<HTMLDivElement>(null);
@@ -232,6 +235,36 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
   const showFullApplicationDetails =
     !isRenewalView || activeTab === 'info' || activeTab === 'original';
+
+  // Workflow history for the printout: use the same source the on-screen
+  // timeline uses (the separately-fetched `workflowHistory` state / the Origin
+  // tab's `originalLicenseHistory`) rather than application.workflowHistories,
+  // which is often empty for renewals and caused "Application History" to be
+  // missing from the print output.
+  const printWorkflowHistory = useMemo(() => {
+    if (isRenewalView && activeTab === 'original') {
+      return originalLicenseHistory && originalLicenseHistory.length > 0
+        ? originalLicenseHistory
+        : (currentDisplayApp as any)?.workflowHistories || [];
+    }
+    return workflowHistory && workflowHistory.length > 0
+      ? workflowHistory
+      : (currentDisplayApp as any)?.workflowHistories || [];
+  }, [isRenewalView, activeTab, originalLicenseHistory, workflowHistory, currentDisplayApp]);
+
+  // Base the printout on currentDisplayApp — the same source the on-screen
+  // details panel renders from — so printing the Original License Details
+  // tab prints the license's original data (currentDisplayApp swaps to
+  // originalLicenseData there) instead of always printing the renewal
+  // application's own data regardless of which tab is active. Documents get
+  // the same origin-tab override used by the on-screen Documents table.
+  const printApplication = useMemo(() => {
+    if (!currentDisplayApp) return null;
+    if (isRenewalView && activeTab === 'original' && originDocuments && originDocuments.length > 0) {
+      return { ...currentDisplayApp, documents: originDocuments };
+    }
+    return currentDisplayApp;
+  }, [currentDisplayApp, isRenewalView, activeTab, originDocuments]);
 
   // Handle params Promise for React 18 compatibility
   useEffect(() => {
@@ -638,6 +671,10 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
   // Print the redesigned dashboard layout directly
   const handleBrowserPrint = () => {
+    // Guard against firing window.print() while the hidden print layout's
+    // document/PDF previews are still rendering asynchronously — otherwise the
+    // printout can show blank thumbnails for Uploaded Documents/attachments.
+    if (!printReady) return;
     window.print();
   };
 
@@ -934,11 +971,16 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                                 <button
                                   type='button'
                                   onClick={handleBrowserPrint}
-                                  className='inline-flex items-center gap-2 px-4 py-2 bg-white text-slate-700 border border-slate-200 rounded-xl shadow-sm text-sm font-semibold hover:bg-slate-50 hover:border-slate-300 transition-all duration-200 print:hidden'
-                                  title='Print application details'
+                                  disabled={!printReady}
+                                  className='inline-flex items-center gap-2 px-4 py-2 bg-white text-slate-700 border border-slate-200 rounded-xl shadow-sm text-sm font-semibold hover:bg-slate-50 hover:border-slate-300 transition-all duration-200 print:hidden disabled:opacity-60 disabled:cursor-not-allowed'
+                                  title={
+                                    printReady
+                                      ? 'Print application details'
+                                      : 'Preparing document previews for printing…'
+                                  }
                                 >
                                   <Printer className='w-4.5 h-4.5 text-slate-500' />
-                                  Print Details
+                                  {printReady ? 'Print Details' : 'Preparing…'}
                                 </button>
                               </div>
                             </div>
@@ -2505,8 +2547,15 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
 
                         <div className='space-y-4'>
                           <div
-                            className='p-4 border border-gray-200 rounded-xl hover:bg-gray-50 hover:shadow-sm cursor-pointer transition-all duration-200'
+                            className={`p-4 border border-gray-200 rounded-xl transition-all duration-200 ${
+                              printReady
+                                ? 'hover:bg-gray-50 hover:shadow-sm cursor-pointer'
+                                : 'opacity-60 cursor-not-allowed'
+                            }`}
                             onClick={handleBrowserPrint}
+                            title={
+                              printReady ? undefined : 'Preparing document previews for printing…'
+                            }
                           >
                             <div className='flex items-center'>
                               <div className='bg-blue-100 p-3 rounded-xl mr-4'>
@@ -2528,7 +2577,9 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
                               <div>
                                 <h4 className='font-semibold text-gray-900'>Print using browser</h4>
                                 <p className='text-sm text-gray-600 mt-1'>
-                                  Opens a printable view in a new window
+                                  {printReady
+                                    ? 'Opens a printable view in a new window'
+                                    : 'Preparing document previews…'}
                                 </p>
                               </div>
                             </div>
@@ -2687,9 +2738,14 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
       )}
 
       {/* Print-Only Layout Component */}
-      {application && (
+      {printApplication && (
         <div className='hidden print:block print:w-full print:bg-white print:text-black'>
-          <PrintApplicationForm application={application} applicantName={applicantName} />
+          <PrintApplicationForm
+            application={printApplication}
+            applicantName={applicantName}
+            workflowHistory={printWorkflowHistory}
+            onReadyChange={setPrintReady}
+          />
         </div>
       )}
 
@@ -2704,7 +2760,17 @@ export default function ApplicationDetailPage({ params }: ApplicationDetailPageP
             background: #fff !important;
             color: #000 !important;
             width: 210mm;
-            height: 297mm;
+            /* Not a fixed height: the app shell normally sets html/body to
+               overflow: hidden/auto for its fixed-viewport layout. Combining
+               that with a fixed height: 297mm (exactly one page) turns the
+               body into a single-page scroll box in Chromium's print engine,
+               which silently swallows every page-break rule below and
+               clips/overlaps anything past page 1. height: auto plus
+               overflow: visible lets the printout paginate across as many
+               pages as the content actually needs. */
+            height: auto !important;
+            min-height: 297mm;
+            overflow: visible !important;
           }
           header,
           footer,

--- a/frontend/src/app/application/components/PrintApplicationForm.tsx
+++ b/frontend/src/app/application/components/PrintApplicationForm.tsx
@@ -1,15 +1,73 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { formatGender, formatApplicationType } from '../../../utils/formatters';
 
 interface PrintApplicationFormProps {
   application: any;
   applicantName: string;
+  // Correctly-fetched workflow history (same source the on-screen timeline uses).
+  // Falls back to application.workflowHistories / application.history when omitted.
+  workflowHistory?: any[];
+  // Called whenever the "is every async preview finished rendering" state changes,
+  // so the caller can hold off calling window.print() until content is actually painted.
+  onReadyChange?: (ready: boolean) => void;
 }
 
+const isImageFile = (name: string, contentType?: string) =>
+  /\.(png|jpe?g|gif|svg)$/i.test(name) || /image/i.test(contentType || '');
+
+const isPdfFile = (name: string, contentType?: string) =>
+  /\.pdf$/i.test(name) || /pdf/i.test(contentType || '');
+
+// Resolve the applicant's headshot the same way sidebarApiCalls.ts and
+// applicationFormatters.ts already do for the fresh/renewal fetch paths.
+// The "Original License Details" tab feeds print a raw License-API object
+// that has neither a normalized `photoUrl` nor `documents`, just whatever
+// file relations the backend included — so fall back to fileUploads,
+// biometricData, and (for the origin tab) the raw documents array too.
+const resolvePhotoUrl = (d: any): string | undefined => {
+  if (!d) return undefined;
+  try {
+    const bioRoot = d.biometricData || d.biometric_data || null;
+    let bio = bioRoot;
+    if (bio && bio.biometricData) bio = bio.biometricData;
+    if (bio && bio.photo && typeof bio.photo.url === 'string' && bio.photo.url.trim()) {
+      return bio.photo.url.trim();
+    }
+
+    if (typeof d.photoUrl === 'string' && d.photoUrl.trim()) return d.photoUrl.trim();
+    if (typeof d.photo === 'string' && d.photo.trim()) return d.photo.trim();
+
+    const isPhotoEntry = (f: any) => {
+      const type = ((f?.fileType || f?.type || '') + '').toUpperCase();
+      const name = ((f?.fileName || f?.name || '') + '').toLowerCase();
+      return type.includes('PHOTOGRAPH') || /(photo|photograph|passport)/.test(name);
+    };
+    const urlOf = (f: any) => (f?.fileUrl || f?.url || '').toString();
+
+    const sources = [d.fileUploads, d.file_uploads, d.documents].filter(Array.isArray);
+    for (const uploads of sources) {
+      const match = uploads.find((f: any) => isPhotoEntry(f) && urlOf(f));
+      if (match) return urlOf(match);
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 // PDF Thumbnail generator component
-function PDFPreview({ url, name }: { url: string; name: string }) {
+function PDFPreview({
+  url,
+  name,
+  onSettled,
+}: {
+  url: string;
+  name: string;
+  onSettled?: () => void;
+}) {
   const [imgSrcs, setImgSrcs] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [pagesCount, setPagesCount] = useState<number | null>(null);
@@ -81,15 +139,19 @@ function PDFPreview({ url, name }: { url: string; name: string }) {
         if (active) {
           setLoading(false);
         }
+        onSettled?.();
       }
     };
 
     if (url) {
       loadPdf();
+    } else {
+      onSettled?.();
     }
     return () => {
       active = false;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url]);
 
   if (loading) {
@@ -106,16 +168,11 @@ function PDFPreview({ url, name }: { url: string; name: string }) {
 
   if (imgSrcs.length > 0) {
     return (
-      <div
-        style={{
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '20px',
-          position: 'relative',
-        }}
-      >
+      // Block layout, not flex: a flex container's children don't reliably
+      // fragment across printed pages in Chromium, which would otherwise
+      // trap every page of a multi-page PDF on a single printed page (and
+      // clip whatever didn't fit) instead of letting them flow naturally.
+      <div style={{ width: '100%', position: 'relative' }}>
         {imgSrcs.map((src, index) => (
           <div
             key={index}
@@ -125,6 +182,7 @@ function PDFPreview({ url, name }: { url: string; name: string }) {
               flexDirection: 'column',
               alignItems: 'center',
               position: 'relative',
+              marginBottom: index < imgSrcs.length - 1 ? '20px' : 0,
               pageBreakInside: 'avoid',
               breakInside: 'avoid',
             }}
@@ -150,9 +208,9 @@ function PDFPreview({ url, name }: { url: string; name: string }) {
 export default function PrintApplicationForm({
   application,
   applicantName,
+  workflowHistory,
+  onReadyChange,
 }: PrintApplicationFormProps) {
-  if (!application) return null;
-
   // Formatting dates helper
   const formatDate = (dateStr: any) => {
     if (!dateStr) return '';
@@ -251,7 +309,7 @@ export default function PrintApplicationForm({
     {}) as any;
   const firDetails = criminal?.firDetails || [];
 
-  const photoUrl = application?.photoUrl || application?.photo;
+  const photoUrl = resolvePhotoUrl(application);
 
   // Determine if this is a renewal application
   const isRenewal =
@@ -262,16 +320,78 @@ export default function PrintApplicationForm({
   // Dynamic header based on application type
   const headerText = isRenewal ? 'Renewal Details' : 'Fresh Details';
 
+  // Prefer the explicitly supplied workflow history (the same data source the
+  // on-screen timeline uses). application.workflowHistories / application.history
+  // can be empty depending on how the application was fetched (e.g. renewals),
+  // which is why "Application History" was missing from the printout.
+  const workflowHistories = useMemo(() => {
+    const source =
+      Array.isArray(workflowHistory) && workflowHistory.length > 0
+        ? workflowHistory
+        : Array.isArray(application?.workflowHistories) && application.workflowHistories.length > 0
+          ? application.workflowHistories
+          : Array.isArray(application?.history)
+            ? application.history
+            : [];
+    return [...source].sort(
+      (a: any, b: any) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime()
+    );
+  }, [workflowHistory, application]);
+
+  // Track every async image/PDF preview so printing can wait until they've
+  // actually painted instead of firing window.print() while thumbnails are
+  // still loading (which prints blank/placeholder boxes).
+  const previewKeys = useMemo(() => {
+    const keys: string[] = [];
+    (application?.documents || []).forEach((doc: any, idx: number) => {
+      const name = doc?.name || doc?.fileName || `Document-${idx + 1}`;
+      const url = doc?.url || doc?.fileUrl || doc?.path || doc?.downloadUrl;
+      if (url && (isImageFile(name, doc?.contentType) || isPdfFile(name, doc?.contentType))) {
+        keys.push(`doc-${idx}`);
+      }
+    });
+    workflowHistories.forEach((entry: any, idx: number) => {
+      const attachments = Array.isArray(entry.attachments) ? entry.attachments : [];
+      attachments.forEach((att: any, attIdx: number) => {
+        const name = att?.name || att?.fileName || `Attachment-${attIdx + 1}`;
+        const url = att?.url || att?.path || att?.downloadUrl;
+        if (url && (isImageFile(name, att?.contentType) || isPdfFile(name, att?.contentType))) {
+          keys.push(`hist-${idx}-att-${attIdx}`);
+        }
+      });
+    });
+    return keys;
+  }, [application, workflowHistories]);
+
+  const [settledPreviews, setSettledPreviews] = useState<Set<string>>(new Set());
+  const markSettled = useCallback((key: string) => {
+    setSettledPreviews(prev => (prev.has(key) ? prev : new Set(prev).add(key)));
+  }, []);
+
+  useEffect(() => {
+    onReadyChange?.(previewKeys.every(key => settledPreviews.has(key)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewKeys, settledPreviews]);
+
+  if (!application) return null;
+
   return (
     <div className='print-form-container font-serif text-black p-4 w-[210mm] max-w-[210mm] mx-auto bg-white box-border'>
       <style jsx global>{`
         @media print {
+          html,
           body {
             background: white !important;
             color: black !important;
             margin: 0 !important;
             padding: 0 !important;
             width: 100% !important;
+            height: auto !important;
+            /* The app shell sets html/body to overflow: hidden/auto for its
+               fixed-viewport layout; left in place during print, Chromium's
+               print engine treats body as a single fixed-size scroll box and
+               ignores page breaks past page 1, clipping everything after. */
+            overflow: visible !important;
           }
           .print-hidden-element,
           header,
@@ -392,9 +512,13 @@ export default function PrintApplicationForm({
         }
 
         .print-documents-grid {
-          display: flex;
-          flex-direction: column;
-          gap: 20px;
+          /* Deliberately block layout, not flex/grid: Chromium's print/PDF
+             fragmentation engine does not reliably honor break-before/
+             break-after on children of a flex or grid container, which was
+             causing the forced page-break-before on .print-doc-card to be
+             silently ignored and documents to bleed across page boundaries
+             mid-image instead of starting cleanly on their own page. */
+          display: block;
           width: 100%;
           box-sizing: border-box;
         }
@@ -403,15 +527,25 @@ export default function PrintApplicationForm({
           border: 1px solid #111;
           background: #fff;
           padding: 10px;
-          display: flex;
-          flex-direction: column;
+          margin-bottom: 20px;
+          /* Block, not flex: a flex container establishes its own
+             fragmentation context in Chromium's print engine, which both
+             suppresses break-before on flex items (documents wouldn't start
+             on a fresh page at all) and stops taller-than-one-page content
+             from flowing across pages (it gets clipped instead). Block
+             layout lets both the forced page break and natural pagination
+             work correctly. */
+          display: block;
           box-sizing: border-box;
           page-break-before: always;
           break-before: page;
-          page-break-inside: avoid;
-          break-inside: avoid;
+          /* Intentionally no page-break-inside/break-inside: avoid here — a
+             multi-page PDF preview is legitimately taller than one printable
+             page, and forcing "avoid" on something that can't fit on one page
+             causes browsers to clip it instead of flowing it onto the next
+             page. Each individual preview image below is capped to fit
+             within one page and marked break-inside: avoid on its own. */
           min-height: 260mm;
-          justify-content: flex-start;
         }
 
         .print-doc-title {
@@ -428,10 +562,12 @@ export default function PrintApplicationForm({
           width: 100%;
           min-height: 220mm;
           border: 1px solid #111;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: flex-start;
+          /* Block, not flex: a flex container establishes its own
+             fragmentation context, which stops Chromium's print engine from
+             breaking a taller-than-one-page child (e.g. a multi-page PDF
+             preview) across pages — it gets clipped instead. */
+          display: block;
+          text-align: center;
           background-color: #fff;
           box-sizing: border-box;
           margin-bottom: 10px;
@@ -442,7 +578,13 @@ export default function PrintApplicationForm({
           width: 100%;
           height: auto;
           max-width: 100%;
+          /* Cap so a tall/portrait photo (or a single PDF page render) can
+             never exceed one printable page (~277mm usable height after
+             margins) and get clipped mid-image; it now scales down instead. */
+          max-height: 230mm;
           object-fit: contain;
+          page-break-inside: avoid;
+          break-inside: avoid;
         }
 
         .print-doc-placeholder {
@@ -835,20 +977,26 @@ export default function PrintApplicationForm({
           <div className='print-documents-grid'>
             {application.documents.map((doc: any, idx: number) => {
               const name = doc?.name || doc?.fileName || `Document-${idx + 1}`;
-              const type = doc?.type || doc?.category || 'Attachment';
-              const url = doc?.url || doc?.path || doc?.downloadUrl;
-              const isImage =
-                /\.(png|jpe?g|gif|svg)$/i.test(name) || /image/i.test(doc?.contentType);
-              const isPdf = /\.pdf$/i.test(name) || /pdf/i.test(doc?.contentType);
+              const type = doc?.type || doc?.fileType || doc?.category || 'Attachment';
+              const url = doc?.url || doc?.fileUrl || doc?.path || doc?.downloadUrl;
+              const isImage = isImageFile(name, doc?.contentType);
+              const isPdf = isPdfFile(name, doc?.contentType);
+              const previewKey = `doc-${idx}`;
 
               return (
                 <div key={idx} className='print-doc-card'>
                   <div className='print-doc-title'>{type}</div>
                   <div className='print-doc-preview-container'>
                     {isImage && url ? (
-                      <img src={url} alt={name} className='print-doc-preview-image' />
+                      <img
+                        src={url}
+                        alt={name}
+                        className='print-doc-preview-image'
+                        onLoad={() => markSettled(previewKey)}
+                        onError={() => markSettled(previewKey)}
+                      />
                     ) : isPdf && url ? (
-                      <PDFPreview url={url} name={name} />
+                      <PDFPreview url={url} name={name} onSettled={() => markSettled(previewKey)} />
                     ) : (
                       <div className='print-doc-placeholder'>Document Preview Not Available</div>
                     )}
@@ -863,16 +1011,6 @@ export default function PrintApplicationForm({
 
       {/* 9. Application History Section */}
       {(() => {
-        const rawHistories = Array.isArray(application.workflowHistories)
-          ? application.workflowHistories
-          : Array.isArray(application.history)
-            ? application.history
-            : [];
-        const workflowHistories = [...rawHistories].sort(
-          (a: any, b: any) =>
-            new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime()
-        );
-
         if (workflowHistories.length === 0) return null;
 
         return (
@@ -912,21 +1050,31 @@ export default function PrintApplicationForm({
               </thead>
               <tbody>
                 {workflowHistories.map((entry: any, idx: number) => {
-                  // Support both WorkflowHistory (new) and history (old) formats
+                  // Support the flattened (Fresh) shape, the nested (Renewal /
+                  // workflow-history-endpoint) shape, and the legacy "history" shape.
+                  const previousUserId = entry.previousUserId ?? entry.previousUser?.id;
+                  const nextUserId = entry.nextUserId ?? entry.nextUser?.id;
                   const userName =
-                    entry.previousUserName || entry.by?.split('(')[0]?.trim() || 'Unknown';
+                    entry.previousUserName ||
+                    entry.previousUser?.username ||
+                    entry.by?.split('(')[0]?.trim() ||
+                    'Unknown';
                   const roleName =
                     entry.previousRoleName ||
+                    entry.previousUser?.role?.name ||
+                    entry.previousRole?.name ||
                     (entry.by ? entry.by.match(/\(([^)]+)\)/)?.[1] || '' : '') ||
                     '—';
-                  const actionTaken = entry.actionTaken || entry.action || '—';
+                  const actionTaken =
+                    entry.actionTaken || entry.action || entry.actiones?.name || '—';
                   const isSameUser =
-                    entry.previousUserId &&
-                    entry.nextUserId &&
-                    Number(entry.previousUserId) === Number(entry.nextUserId);
+                    previousUserId && nextUserId && Number(previousUserId) === Number(nextUserId);
+                  const nextUserName = entry.nextUserName || entry.nextUser?.username;
+                  const nextRoleName =
+                    entry.nextRoleName || entry.nextUser?.role?.name || entry.nextRole?.name;
                   const forwardedTo =
-                    entry.nextUserName && !isSameUser
-                      ? `${entry.nextUserName}${entry.nextRoleName ? ` (${entry.nextRoleName})` : ''}`
+                    nextUserName && !isSameUser
+                      ? `${nextUserName}${nextRoleName ? ` (${nextRoleName})` : ''}`
                       : '—';
                   const rawRemarks = entry.remarks || entry.comments || '';
                   const hasRemarks = !!rawRemarks;
@@ -1071,18 +1219,14 @@ export default function PrintApplicationForm({
                                 <div style={{ fontWeight: 'bold', marginBottom: '6px' }}>
                                   Attachments:
                                 </div>
-                                <div
-                                  style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
-                                >
+                                <div>
                                   {attachments.map((att: any, attIdx: number) => {
                                     const name =
                                       att?.name || att?.fileName || `Attachment-${attIdx + 1}`;
                                     const url = att?.url || att?.path || att?.downloadUrl;
-                                    const isImage =
-                                      /\.(png|jpe?g|gif|svg)$/i.test(name) ||
-                                      /image/i.test(att?.contentType);
-                                    const isPdf =
-                                      /\.pdf$/i.test(name) || /pdf/i.test(att?.contentType);
+                                    const isImage = isImageFile(name, att?.contentType);
+                                    const isPdf = isPdfFile(name, att?.contentType);
+                                    const previewKey = `hist-${idx}-att-${attIdx}`;
 
                                     return (
                                       <div
@@ -1092,8 +1236,11 @@ export default function PrintApplicationForm({
                                           padding: '10px',
                                           backgroundColor: '#fff',
                                           maxWidth: '100%',
-                                          pageBreakInside: 'avoid',
-                                          breakInside: 'avoid',
+                                          // No break-inside: avoid here — a multi-page PDF
+                                          // attachment must be allowed to flow across pages
+                                          // instead of being clipped. The image/PDF page
+                                          // previews below are individually capped and
+                                          // marked break-inside: avoid instead.
                                           marginTop: '6px',
                                         }}
                                       >
@@ -1126,15 +1273,22 @@ export default function PrintApplicationForm({
                                             <img
                                               src={url}
                                               alt={name}
+                                              className='print-doc-preview-image'
                                               style={{
                                                 width: '100%',
                                                 height: 'auto',
                                                 maxWidth: '100%',
                                                 objectFit: 'contain',
                                               }}
+                                              onLoad={() => markSettled(previewKey)}
+                                              onError={() => markSettled(previewKey)}
                                             />
                                           ) : isPdf && url ? (
-                                            <PDFPreview url={url} name={name} />
+                                            <PDFPreview
+                                              url={url}
+                                              name={name}
+                                              onSettled={() => markSettled(previewKey)}
+                                            />
                                           ) : (
                                             <div
                                               style={{

--- a/frontend/src/app/application/components/PrintApplicationForm.tsx
+++ b/frontend/src/app/application/components/PrintApplicationForm.tsx
@@ -334,7 +334,8 @@ export default function PrintApplicationForm({
             ? application.history
             : [];
     return [...source].sort(
-      (a: any, b: any) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime()
+      (a: any, b: any) =>
+        new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime()
     );
   }, [workflowHistory, application]);
 

--- a/frontend/src/app/cancelForm/new/page.tsx
+++ b/frontend/src/app/cancelForm/new/page.tsx
@@ -14,7 +14,7 @@ export default function NewCancelFormPage() {
           <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
-          Back to Listings
+          Go Back
         </button>
       </div>
       <SubmitCancelForm />

--- a/frontend/src/app/forms/renewal/page.tsx
+++ b/frontend/src/app/forms/renewal/page.tsx
@@ -3816,6 +3816,16 @@ function RenewalFormPageContent() {
           className='absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/50 backdrop-blur-[2px]'
           aria-hidden='true'
         />
+        <button
+          type='button'
+          onClick={() => window.history.back()}
+          className='absolute top-6 left-6 z-20 inline-flex items-center gap-2 text-sm font-medium text-white/90 hover:text-white bg-black/20 hover:bg-black/30 backdrop-blur-sm px-4 py-2 rounded-md transition-colors'
+        >
+          <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+            <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M10 19l-7-7m0 0l7-7m0 7h18' />
+          </svg>
+          Go Back
+        </button>
         <div className='relative flex-grow flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 z-10'>
           <div className='max-w-md w-full space-y-6 bg-white/90 p-10 rounded-lg shadow-xl backdrop-blur-sm border border-white/40 transition-all duration-300'>
             {verificationChecking && verificationStatus === 'ENTER_LICENSE_ID' ? (

--- a/frontend/src/components/cancelForm/SubmitCancelForm.tsx
+++ b/frontend/src/components/cancelForm/SubmitCancelForm.tsx
@@ -6,6 +6,52 @@ import CancelService from '@/api/cancelService';
 import { ApplicationService } from '@/api/applicationService';
 import MantraSDKService from '@/services/mantraSDKService';
 import toast from 'react-hot-toast';
+import { useLayout } from '../../config/layoutContext';
+
+// Full-screen background + centered card shell used by every pre-verification
+// gate screen, matching the License Renewal Verification page's design
+// exactly (same background image, gradient overlay, card sizing/shadow).
+function VerificationShell({
+  children,
+  showBackButton,
+}: {
+  children: React.ReactNode;
+  showBackButton?: boolean;
+}) {
+  return (
+    // Fixed, not just min-h-screen: this renders inside /cancelForm/new's
+    // padded page shell (with its own "Back to Listings" bar), which isn't
+    // present on the Renewal page. Pinning to the viewport lets the card sit
+    // centered in the true viewport — matching Renewal exactly — regardless
+    // of the parent page's layout.
+    <div
+      className="fixed inset-0 z-40 flex flex-col bg-cover bg-center bg-fixed overflow-auto bg-[url('/backgroundIMGALMS.jpeg')]"
+      role='main'
+    >
+      <div
+        className='absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/50 backdrop-blur-[2px]'
+        aria-hidden='true'
+      />
+      {showBackButton && (
+        <button
+          type='button'
+          onClick={() => window.history.back()}
+          className='absolute top-6 left-6 z-20 inline-flex items-center gap-2 text-sm font-medium text-white/90 hover:text-white bg-black/20 hover:bg-black/30 backdrop-blur-sm px-4 py-2 rounded-md transition-colors'
+        >
+          <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+            <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M10 19l-7-7m0 0l7-7m0 7h18' />
+          </svg>
+          Go Back
+        </button>
+      )}
+      <div className='relative flex-grow flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 z-10'>
+        <div className='max-w-md w-full space-y-6 bg-white/90 p-10 rounded-lg shadow-xl backdrop-blur-sm border border-white/40 transition-all duration-300'>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function SubmitCancelForm() {
   const router = useRouter();
@@ -42,6 +88,16 @@ export default function SubmitCancelForm() {
     cancellationReason: '',
     remarks: ''
   });
+
+  // Hide the persistent app header for the entire cancellation flow — every
+  // screen here (License ID entry, biometric step, "not allowed", and the
+  // actual cancellation form) uses its own full-width background takeover
+  // with no navbar, matching the Renewal flow.
+  const { setShowHeader } = useLayout();
+  useEffect(() => {
+    setShowHeader(false);
+    return () => setShowHeader(true);
+  }, [setShowHeader]);
 
   useEffect(() => {
     if (urlLicenseId) {
@@ -298,37 +354,77 @@ export default function SubmitCancelForm() {
     }
   };
 
-  if (verificationChecking) {
+  if (verificationChecking && verificationStatus === 'ENTER_APP_ID') {
     return (
-      <div className='max-w-2xl mx-auto w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8 flex flex-col items-center justify-center min-h-[300px]'>
-        <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-red-600 mb-4'></div>
-        <p className='text-gray-600 font-medium'>Fetching application details...</p>
-      </div>
+      <VerificationShell>
+        <div className='space-y-6 py-8 text-center'>
+          <div className='mx-auto w-12 h-12 border-4 border-[#001F54] border-t-transparent rounded-full animate-spin flex items-center justify-center'>
+            <span className='text-xl'>🪪</span>
+          </div>
+          <h3 className='text-lg font-bold text-gray-900'>Loading License Details...</h3>
+          <p className='text-sm text-gray-500'>Fetching application details</p>
+        </div>
+      </VerificationShell>
     );
   }
 
   if (verificationStatus === 'ENTER_APP_ID') {
     return (
-      <div className='max-w-2xl mx-auto w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8'>
-        <h2 className='text-2xl font-bold text-gray-900 mb-4'>Verification Required</h2>
-        <p className='text-sm text-gray-500 mb-6'>Please load the target License ID through the header menu or enter it here to perform verification.</p>
-        <div className='space-y-4'>
-          <input
-            type='text'
-            placeholder='Enter License ID or License Number'
-            className='w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-red-500 focus:border-red-500'
-            value={formData.licenseId}
-            onChange={(e) => setFormData(prev => ({ ...prev, licenseId: e.target.value }))}
-          />
-          <button
-            onClick={() => checkBiometricRequirement(formData.licenseId)}
-            className='px-6 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md font-medium'
-          >
-            Check License
-          </button>
-          {verificationError && <p className='text-sm text-red-600 mt-2'>{verificationError}</p>}
+      <VerificationShell showBackButton>
+        <div className='space-y-6'>
+          <div className='text-center'>
+            <div className='mb-6 flex justify-center'>
+              <img
+                src='/icon-alms.svg'
+                alt='ALMS Logo'
+                width={100}
+                height={100}
+                className='drop-shadow-md h-auto'
+              />
+            </div>
+            <h2 className='text-2xl font-bold tracking-tight text-gray-900'>
+              License Cancellation Verification
+            </h2>
+            <p className='mt-2 text-sm text-gray-600'>
+              Please enter your License ID or License Number to verify your identity and start
+              the cancellation process.
+            </p>
+          </div>
+
+          {verificationError && (
+            <div className='rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700'>
+              {verificationError}
+            </div>
+          )}
+
+          <div className='space-y-4'>
+            <div>
+              <label
+                htmlFor='cancel-license-id'
+                className='block text-sm font-semibold text-gray-700 mb-1'
+              >
+                License ID or License Number
+              </label>
+              <input
+                id='cancel-license-id'
+                type='text'
+                value={formData.licenseId}
+                onChange={e => setFormData(prev => ({ ...prev, licenseId: e.target.value }))}
+                placeholder='e.g. 12 or LUAN20260703132128000625'
+                className='w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#D4AF37] focus:border-[#D4AF37] bg-white text-gray-900 font-semibold'
+              />
+            </div>
+
+            <button
+              onClick={() => checkBiometricRequirement(formData.licenseId)}
+              disabled={verificationChecking || !formData.licenseId.trim()}
+              className='w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-md text-sm font-semibold text-gray-900 bg-[#D4AF37] hover:bg-[#C4A02F] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#D4AF37] disabled:opacity-60 disabled:cursor-not-allowed transition-all hover:scale-[1.01]'
+            >
+              {verificationChecking ? 'Checking...' : 'Verify / Continue'}
+            </button>
+          </div>
         </div>
-      </div>
+      </VerificationShell>
     );
   }
 
@@ -446,15 +542,28 @@ export default function SubmitCancelForm() {
 
   if (verificationStatus === 'FAILED') {
     return (
-      <div className='max-w-2xl mx-auto w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8'>
-        <div className='text-center'>
-          <div className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 mb-4'>
-            <svg className='w-8 h-8 text-red-600' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-            </svg>
+      <VerificationShell>
+        <div className='text-center space-y-5'>
+          <div className='relative mx-auto w-20 h-20'>
+            <div className='absolute inset-0 rounded-full bg-red-400 animate-ping opacity-20' aria-hidden='true' />
+            <div className='relative inline-flex items-center justify-center w-20 h-20 rounded-full bg-red-100 ring-8 ring-red-50'>
+              <svg className='w-9 h-9 text-red-600' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
+              </svg>
+            </div>
           </div>
-          <h2 className='text-xl font-bold text-gray-900 mb-2'>Cancellation Not Allowed</h2>
-          <p className='text-red-600 font-medium'>{verificationError || 'This license has already been cancelled.'}</p>
+
+          <div>
+            <h2 className='text-2xl font-bold tracking-tight text-gray-900'>Cancellation Not Allowed</h2>
+            <p className='mt-1.5 text-sm text-gray-500'>
+              We couldn&apos;t start a new cancellation request for this license.
+            </p>
+          </div>
+
+          <div className='rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 text-left'>
+            {verificationError || 'This license has already been cancelled.'}
+          </div>
+
           <button
             type='button'
             onClick={() => {
@@ -462,27 +571,47 @@ export default function SubmitCancelForm() {
               setVerificationError(null);
               setFormData(prev => ({ ...prev, licenseId: '' }));
             }}
-            className='mt-6 px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-medium transition-colors'
+            className='w-full flex items-center justify-center gap-2 py-3 px-4 border border-transparent rounded-md shadow-md text-sm font-semibold text-gray-900 bg-[#D4AF37] hover:bg-[#C4A02F] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#D4AF37] transition-all hover:scale-[1.01]'
           >
+            <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M10 19l-7-7m0 0l7-7m0 7h18' />
+            </svg>
             Try Another License
           </button>
         </div>
-      </div>
+      </VerificationShell>
     );
   }
 
-  // VERIFIED: Render SubmitCancelForm
+  // VERIFIED: Render SubmitCancelForm — same full-viewport background
+  // takeover as the verification gate screens (fixed, not just min-h-screen,
+  // so it spans the true viewport edge-to-edge regardless of this page's
+  // padded parent container).
   return (
-    <div className='max-w-2xl mx-auto w-full'>
-      <div className='bg-white rounded-lg shadow-sm border border-gray-200 p-8'>
-        <div className='mb-6 border-b border-gray-200 pb-4'>
-          <h2 className='text-2xl font-bold text-gray-900'>Initiate License Cancellation</h2>
-          <p className='text-sm text-gray-500 mt-2'>Submit a request to permanently cancel an existing approved license application.</p>
+    <div
+      className="fixed inset-0 z-40 flex items-start justify-center bg-cover bg-center bg-fixed overflow-auto bg-[url('/backgroundIMGALMS.jpeg')] py-10 px-4"
+    >
+      <div
+        className='absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/50 backdrop-blur-[2px]'
+        aria-hidden='true'
+      />
+      <div className='relative z-10 max-w-2xl w-full my-auto'>
+      <div className='bg-white/90 backdrop-blur-sm rounded-lg shadow-xl border border-white/40 p-8'>
+        <div className='mb-6 pb-5 border-b border-gray-200 flex items-start gap-4'>
+          <div className='flex-shrink-0 w-11 h-11 rounded-full bg-red-50 ring-4 ring-red-50/60 flex items-center justify-center'>
+            <svg className='w-5 h-5 text-red-600' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 3v2m6-2v2M4 7h16M5 7v12a2 2 0 002 2h10a2 2 0 002-2V7M9 12h6' />
+            </svg>
+          </div>
+          <div>
+            <h2 className='text-2xl font-bold tracking-tight text-gray-900'>Initiate License Cancellation</h2>
+            <p className='text-sm text-gray-500 mt-1'>Submit a request to permanently cancel an existing approved license application.</p>
+          </div>
         </div>
 
         <form onSubmit={handleSubmit} className='space-y-6'>
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-            <div className='space-y-2'>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4 bg-slate-50 rounded-xl p-4 border border-slate-200'>
+            <div className='space-y-1.5'>
                <label htmlFor='licenseId' className='block text-sm font-semibold text-gray-700'>
                  Target License ID
                </label>
@@ -492,12 +621,17 @@ export default function SubmitCancelForm() {
                  name='licenseId'
                  value={formData.licenseId}
                  disabled
-                 className='w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 cursor-not-allowed text-gray-700 font-medium'
+                 className='w-full px-4 py-2.5 border border-gray-200 rounded-md bg-white cursor-not-allowed text-gray-800 font-semibold shadow-sm'
                />
-               <p className='text-xs text-gray-500'>Verified target ID of the license.</p>
+               <p className='text-xs text-gray-500 flex items-center gap-1'>
+                 <svg className='w-3.5 h-3.5 text-emerald-500 flex-shrink-0' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                   <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 13l4 4L19 7' />
+                 </svg>
+                 Verified target ID of the license.
+               </p>
             </div>
 
-            <div className='space-y-2'>
+            <div className='space-y-1.5'>
                <label htmlFor='applicationType' className='block text-sm font-semibold text-gray-700'>
                  Application Type
                </label>
@@ -507,12 +641,12 @@ export default function SubmitCancelForm() {
                  name='applicationType'
                  value="Cancel Application"
                  disabled
-                 className='w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 cursor-not-allowed text-gray-700 font-medium'
+                 className='w-full px-4 py-2.5 border border-gray-200 rounded-md bg-white cursor-not-allowed text-gray-800 font-semibold shadow-sm'
                />
             </div>
           </div>
 
-          <div className='space-y-2'>
+          <div className='space-y-1.5'>
             <label htmlFor='cancellationReason' className='block text-sm font-semibold text-gray-700'>
               Reason for Cancellation <span className='text-red-500'>*</span>
             </label>
@@ -523,12 +657,12 @@ export default function SubmitCancelForm() {
               value={formData.cancellationReason}
               onChange={handleChange}
               required
-              className='w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-red-500 focus:border-red-500'
+              className='w-full px-4 py-2.5 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500/40 focus:border-red-500 transition-colors'
               placeholder='E.g., Voluntary surrender by applicant'
             />
           </div>
 
-          <div className='space-y-2'>
+          <div className='space-y-1.5'>
             <label htmlFor='remarks' className='block text-sm font-semibold text-gray-700'>
               Additional Remarks
             </label>
@@ -538,23 +672,23 @@ export default function SubmitCancelForm() {
               value={formData.remarks}
               onChange={handleChange}
               rows={4}
-              className='w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-red-500 focus:border-red-500 resize-none'
+              className='w-full px-4 py-2.5 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500/40 focus:border-red-500 resize-none transition-colors'
               placeholder='Provide any additional context or details for this request (optional)'
             />
           </div>
 
-          <div className='pt-4 flex justify-end gap-4 border-t border-gray-100'>
+          <div className='pt-5 flex justify-end gap-3 border-t border-gray-100'>
             <button
               type='button'
               onClick={() => router.back()}
-              className='px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-medium transition-colors'
+              className='px-6 py-2.5 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-semibold transition-colors'
             >
               Cancel
             </button>
             <button
               type='submit'
               disabled={loading}
-              className='px-6 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md font-medium shadow-sm flex items-center transition-colors disabled:opacity-70 disabled:cursor-not-allowed'
+              className='px-6 py-2.5 bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white rounded-md font-semibold shadow-md flex items-center transition-all hover:scale-[1.02] disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:scale-100'
             >
               {loading ? (
                 <>
@@ -564,10 +698,18 @@ export default function SubmitCancelForm() {
                   </svg>
                   Submitting
                 </>
-              ) : 'Submit Request'}
+              ) : (
+                <>
+                  <svg className='w-4 h-4 mr-2' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 13l4 4L19 7' />
+                  </svg>
+                  Submit Request
+                </>
+              )}
             </button>
           </div>
         </form>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Identified multiple print issues:
Uploaded Documents and Application History not printing.
Large images getting cut off due to missing page-break handling.
Print output not respecting the active tab.
Defined print workflow:
Fresh Application → Print Fresh Details.
Renewal Application → Print Renewal Info or License Details based on active tab.
Cancellation Application → Print Cancellation Info or License Details based on active tab.
Found Renewal print bug:
/renewalApplication/:id?tab=original should print License Details, but it prints incorrect data.
Discussed Cancellation Verification UI redesign:
Reuse the same full-screen background and centered card layout from the Renewal Verification page.
Keep business logic unchanged.
Final requirement:
When a cancellation request already exists, show the "Cancellation Not Allowed" card inside the same Renewal Verification-style background/layout instead of the current plain page.
<img width="1867" height="934" alt="image" src="https://github.com/user-attachments/assets/66f0983f-58f8-46c2-904d-d34d40cf162c" />
